### PR TITLE
feat(#3): relocate bible catalog ORM to bible schema

### DIFF
--- a/portal/models/bible/__init__.py
+++ b/portal/models/bible/__init__.py
@@ -1,0 +1,7 @@
+"""
+Bible catalog models under the bible schema.
+"""
+
+from .catalog import BibleBook, BibleVerse, BibleVersion
+
+__all__ = ["BibleBook", "BibleVerse", "BibleVersion"]

--- a/portal/models/bible/catalog.py
+++ b/portal/models/bible/catalog.py
@@ -1,28 +1,29 @@
 """
-Bible models
+Bible catalog ORM: versions, books, and verses (verse-per-row).
+
+Tables live in the bible schema as versions / books / verses (ADR 0004).
+Passage remains an addressing/read concept over verses — no bible_passages table.
 """
 
 import sqlalchemy as sa
-from sqlalchemy import Column, UniqueConstraint
+from sqlalchemy import Column
 from sqlalchemy.dialects.postgresql import UUID
 
 from portal.libs.database.orm import ModelBase
-
-from .mixins import AuditCreatedAtMixin, AuditUpdatedAtMixin, SortableMixin
+from portal.models.mixins import AuditCreatedAtMixin, AuditUpdatedAtMixin, SortableMixin
 
 
 class BibleVersion(ModelBase, AuditCreatedAtMixin, AuditUpdatedAtMixin):
-    """
-    Bible Version Model
-    """
+    """Bible Version Model."""
 
-    __tablename__ = "bible_versions"
+    __tablename__ = "versions"
+    __extra_table_args__ = ({"comment": "Bible versions table"},)
 
     youversion_bible_id = Column(sa.String(20), nullable=False, unique=True, comment="YouVersion bible_id, e.g., '1392'", index=True)
     abbreviation = Column(sa.String(50), nullable=False, comment="English abbreviation, e.g., 'CCBT'")
     title = Column(sa.String(255), nullable=False, comment="English title")
-    localized_title = Column(sa.String(255), nullable=False, comment="Localized title, e.g., '當代譯本'")
-    localized_abbreviation = Column(sa.String(50), nullable=True, comment="Localized abbreviation, e.g., 'CCB'")
+    localized_title = Column(sa.String(255), nullable=False, comment="Localized title")
+    localized_abbreviation = Column(sa.String(50), nullable=True, comment="Localized abbreviation")
     language_tag = Column(sa.String(20), nullable=False, comment="Language tag, e.g., 'zh-Hant-TW'", index=True)
     copyright = Column(sa.Text, nullable=True, comment="Copyright information")
     promotional_content = Column(sa.Text, nullable=True, comment="Promotional content")
@@ -31,51 +32,43 @@ class BibleVersion(ModelBase, AuditCreatedAtMixin, AuditUpdatedAtMixin):
     organization_id = Column(UUID, nullable=True, comment="Organization ID")
     is_active = Column(sa.Boolean, default=True, nullable=False, comment="Is version active", index=True)
 
-    __table_args__ = ({"comment": "Bible versions table"},)
-
 
 class BibleBook(ModelBase, AuditCreatedAtMixin, AuditUpdatedAtMixin, SortableMixin):
     """
-    Bible Book Model
-    Note: Book belongs to a Bible version. Each version has its own set of books.
-    This design simplifies BibleVerse structure (only needs book_id instead of both version_id and book_id).
+    Bible Book Model.
+
+    Book belongs to a Bible version. Each version has its own set of books.
+    This design simplifies BibleVerse structure (only needs book_id).
     """
 
-    __tablename__ = "bible_books"
+    __tablename__ = "books"
+    __extra_table_args__ = (sa.UniqueConstraint("bible_version_id", "book_code"), {"comment": "Bible books table - books belong to a specific version"})
 
-    bible_version_id = Column(UUID, sa.ForeignKey("bible_versions.id", ondelete="CASCADE"), nullable=False, comment="Bible version ID", index=True)
+    bible_version_id = Column(UUID, sa.ForeignKey(BibleVersion.id, ondelete="CASCADE"), nullable=False, comment="Bible version ID", index=True)
     book_code = Column(sa.String(10), nullable=False, comment="Book code, e.g., 'GEN', 'MAT'", index=True)
     title = Column(sa.String(100), nullable=False, comment="Book title")
     full_title = Column(sa.String(100), nullable=True, comment="Full book title")
-    abbreviation = Column(sa.String(10), nullable=True, comment="Book abbreviation, e.g., '創'")
+    abbreviation = Column(sa.String(10), nullable=True, comment="Book abbreviation")
     canon = Column(sa.String(20), nullable=False, comment="Canon type: 'old_testament' or 'new_testament'", index=True)
     chapter_count = Column(sa.Integer, nullable=False, comment="Number of chapters in this book")
-
-    __table_args__ = (
-        UniqueConstraint("bible_version_id", "book_code", name="uq_bible_books_version_book_code"),
-        {"comment": "Bible books table - books belong to a specific version"},
-    )
 
 
 class BibleVerse(ModelBase, AuditCreatedAtMixin, AuditUpdatedAtMixin):
     """
-    Bible Verse Model
-    Note: Verse belongs to a book. Since book belongs to a version,
-    we only need book_id to identify both the book and the version.
+    Bible Verse Model (verse-per-row).
+
+    Verse belongs to a book; book belongs to a version, so book_id identifies both.
     """
 
-    __tablename__ = "bible_verses"
-
-    book_id = Column(
-        UUID, sa.ForeignKey("bible_books.id", ondelete="CASCADE"), nullable=False, comment="Book ID (which also identifies the version)", index=True
+    __tablename__ = "verses"
+    __extra_table_args__ = (
+        sa.UniqueConstraint("book_id", "passage_id"),
+        sa.UniqueConstraint("book_id", "chapter", "verse"),
+        {"comment": "Bible verses table - verse belongs to a book (which belongs to a version)"},
     )
+
+    book_id = Column(UUID, sa.ForeignKey(BibleBook.id, ondelete="CASCADE"), nullable=False, comment="Book ID (which also identifies the version)", index=True)
     chapter = Column(sa.Integer, nullable=False, comment="Chapter number", index=True)
     verse = Column(sa.Integer, nullable=False, comment="Verse number", index=True)
     passage_id = Column(sa.String(50), nullable=False, comment="Passage ID, e.g., 'GEN.1.1'", index=True)
     content = Column(sa.Text, nullable=False, comment="Verse content (version-specific)")
-
-    __table_args__ = (
-        UniqueConstraint("book_id", "passage_id", name="uq_bible_verses_book_passage"),
-        UniqueConstraint("book_id", "chapter", "verse", name="uq_bible_verses_book_chapter_verse"),
-        {"comment": "Bible verses table - verse belongs to a book (which belongs to a version)"},
-    )

--- a/tests/models/bible/test_bible_catalog_schema.py
+++ b/tests/models/bible/test_bible_catalog_schema.py
@@ -1,0 +1,18 @@
+"""ORM seam: bible catalog tables live under the bible schema with plural names."""
+
+from portal.models import BibleBook, BibleVerse, BibleVersion
+
+
+def test_bible_version_maps_to_versions_table() -> None:
+    assert BibleVersion.__table__.schema == "bible"
+    assert BibleVersion.__tablename__ == "versions"
+
+
+def test_bible_book_maps_to_books_table() -> None:
+    assert BibleBook.__table__.schema == "bible"
+    assert BibleBook.__tablename__ == "books"
+
+
+def test_bible_verse_maps_to_verses_table() -> None:
+    assert BibleVerse.__table__.schema == "bible"
+    assert BibleVerse.__tablename__ == "verses"


### PR DESCRIPTION
## Summary

Relocate the bible catalog ORM from `public.bible_*` into `portal.models.bible` so ModelBase targets `bible.versions`, `bible.books`, and `bible.verses` (verse-per-row, ADR 0004). Repository, CLI import, and HTTP read paths keep working via existing `portal.models` re-exports. No `bible_passages` table; no agent edits under `alembic/versions/` (human migration still required for the data move).

Closes #3

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Explicit plural `__tablename__` values (`versions` / `books` / `verses`) because ModelBase would otherwise singularize class names.
- Use `__extra_table_args__` (not class-level `__table_args__`) so schema injection still applies.
- FKs use `BibleVersion.id` / `BibleBook.id` instead of unqualified string table names.

## Testing

- [x] `uv run pytest`
- [x] `uv run pytest tests/models/bible/test_bible_catalog_schema.py tests/application/bible/ -v`

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge

Made with [Cursor](https://cursor.com)