### PR TITLE
feat(auth): End user register/login HTTP for rooted-app

### DIFF
--- a/portal/application/app/end_user_provisioning_service.py
+++ b/portal/application/app/end_user_provisioning_service.py
@@ -41,12 +41,15 @@ class EndUserProvisioningService:
 
         auth_user_id = uuid.uuid4()
         password_hash = self._password_provider.hash_password(command.password)
+        # Password signup verifies the credential for app use; email magic-link
+        # verification is a separate channel (ADR 0003). Admin-only rows stay unverified.
         await self._user_repository.create_credential(
             auth_user_id=auth_user_id,
             email=command.email.strip().lower(),
             password_hash=password_hash,
             is_admin=command.is_admin,
             is_superuser=command.is_superuser,
+            verified=command.create_end_user,
         )
 
         if not command.create_end_user:

--- a/portal/application/auth/app_auth_service.py
+++ b/portal/application/auth/app_auth_service.py
@@ -1,0 +1,127 @@
+"""
+App (End user) password register / login use cases.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID, uuid4
+
+from portal.application.app.commands import ProvisionIdentityCommand
+from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.commands import AppLoginCommand, AppRegisterCommand
+from portal.application.auth.mappers import normalize_user_for_token
+from portal.application.auth.member_web_app_resolver import resolve_request_app_code
+from portal.application.auth.results import MemberLoginResult, MemberProfileResult, TokenResult, UserSensitive
+from portal.config import settings
+from portal.domain.app.ports import EndUserRepositoryPort, PreferencesRepositoryPort
+from portal.domain.auth.member_web_app import MemberWebAppRegistry
+from portal.domain.auth.ports import UserRepositoryPort
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.consts.enums import AccessTokenAudType
+from portal.libs.tracing.distributed_trace import distributed_trace
+from portal.providers.jwt_provider import JWTProvider
+from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
+from portal.providers.password_provider import PasswordProvider
+from portal.providers.refresh_token_provider import RefreshTokenProvider
+
+
+class AppAuthService:
+    """
+    Password register/login for End users.
+
+    Issues member JWTs via shared providers; product identity in the response
+    is app.user.id (End user), not auth.user.id.
+    """
+
+    def __init__(
+        self,
+        provisioning_service: EndUserProvisioningService,
+        user_repository: UserRepositoryPort,
+        end_user_repository: EndUserRepositoryPort,
+        preferences_repository: PreferencesRepositoryPort,
+        password_provider: PasswordProvider,
+        jwt_provider: JWTProvider,
+        refresh_token_provider: RefreshTokenProvider,
+        member_refresh_app_binding_provider: Optional[MemberRefreshAppBindingProvider],
+        member_web_app_registry: MemberWebAppRegistry,
+    ):
+        self._provisioning_service = provisioning_service
+        self._user_repository = user_repository
+        self._end_user_repository = end_user_repository
+        self._preferences_repository = preferences_repository
+        self._password_provider = password_provider
+        self._jwt_provider = jwt_provider
+        self._refresh_token_provider = refresh_token_provider
+        self._member_refresh_app_binding_provider = member_refresh_app_binding_provider
+        self._member_web_app_registry = member_web_app_registry
+
+    def _resolve_app_code(self) -> str:
+        app_code = resolve_request_app_code(self._member_web_app_registry, required=True)
+        assert app_code is not None
+        return app_code
+
+    @distributed_trace()
+    async def register(self, command: AppRegisterCommand) -> MemberLoginResult:
+        app_code = self._resolve_app_code()
+        provisioned = await self._provisioning_service.provision(
+            ProvisionIdentityCommand(email=command.email, password=command.password, display_name=command.display_name, create_end_user=True)
+        )
+        if provisioned.end_user_id is None:
+            raise UnauthorizedException(detail="End user was not provisioned")
+
+        user = await self._user_repository.get_sensitive_by_email_without_profile(command.email.strip().lower())
+        if not user:
+            raise UnauthorizedException(detail="User not found after register")
+
+        preferences = await self._preferences_repository.get_by_user_id(provisioned.end_user_id)
+        preferred_name = preferences.display_name if preferences else command.display_name
+        return await self._issue_member_tokens(user=user, app_code=app_code, end_user_id=provisioned.end_user_id, preferred_name=preferred_name)
+
+    @distributed_trace()
+    async def login(self, command: AppLoginCommand) -> MemberLoginResult:
+        app_code = self._resolve_app_code()
+        email = command.email.strip().lower()
+        user = await self._user_repository.get_sensitive_by_email_without_profile(email)
+        if not user or not user.password_hash:
+            raise UnauthorizedException(detail="Invalid email or password")
+        if not self._password_provider.verify_password(command.password, user.password_hash):
+            raise UnauthorizedException(detail="Invalid email or password")
+        if not user.verified or not user.is_active:
+            raise UnauthorizedException(detail="User is not allowed to access the app")
+
+        end_user = await self._end_user_repository.get_by_auth_user_id(user.id)
+        if not end_user:
+            raise UnauthorizedException(detail="Invalid email or password")
+
+        preferences = await self._preferences_repository.get_by_user_id(end_user.id)
+        preferred_name = preferences.display_name if preferences else None
+        return await self._issue_member_tokens(user=user, app_code=app_code, end_user_id=end_user.id, preferred_name=preferred_name)
+
+    async def _issue_member_tokens(self, *, user: UserSensitive, app_code: str, end_user_id: UUID, preferred_name: Optional[str]) -> MemberLoginResult:
+        token_user = normalize_user_for_token(user)
+        if preferred_name:
+            token_user = token_user.model_copy(update={"preferred_name": preferred_name, "first_name": preferred_name})
+
+        family_id = uuid4()
+        device_id = uuid4()
+        access_token = self._jwt_provider.create_access_token(user=token_user, family_id=family_id, aud_type=AccessTokenAudType.USER, azp=app_code)
+        refresh_token = await self._refresh_token_provider.issue(user_id=user.id, device_id=device_id, family_id=family_id)
+        if self._member_refresh_app_binding_provider:
+            await self._member_refresh_app_binding_provider.bind(family_id, app_code)
+
+        now = datetime.now(timezone.utc)
+        await self._user_repository.update_last_login_at(user_id=user.id, last_login_at=now)
+
+        expires_in = settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        token = TokenResult(access_token=access_token, refresh_token=refresh_token, token_type="bearer", expires_in=expires_in)
+        member = MemberProfileResult(
+            id=end_user_id,
+            email=user.email or "",
+            first_name=preferred_name or "",
+            last_name="",
+            preferred_name=preferred_name,
+            roles=[],
+            preferred_locale_id=user.preferred_locale_id,
+            last_login_at=user.last_login_at,
+        )
+        return MemberLoginResult(member=member, token=token)

--- a/portal/application/auth/commands.py
+++ b/portal/application/auth/commands.py
@@ -14,6 +14,21 @@ class LoginCommand(BaseModel):
     password: str = Field(..., description="Admin password")
 
 
+class AppRegisterCommand(BaseModel):
+    """End user password registration command."""
+
+    email: str = Field(..., description="End user email")
+    password: str = Field(..., description="End user password")
+    display_name: str = Field(..., description="Display name stored on Preferences")
+
+
+class AppLoginCommand(BaseModel):
+    """End user password login command."""
+
+    email: str = Field(..., description="End user email")
+    password: str = Field(..., description="End user password")
+
+
 class LoginWithoutValidateCommand(BaseModel):
     """Dev-only login command that skips password validation."""
 

--- a/portal/application/auth/member_web_app_resolver.py
+++ b/portal/application/auth/member_web_app_resolver.py
@@ -12,6 +12,9 @@ from portal.libs.contexts.request_context import get_request_context
 def resolve_request_app_code(registry: MemberWebAppRegistry, *, required: bool = True) -> Optional[str]:
     """
     Resolve app_code from Origin (preferred) or Referer on the current request.
+
+    When Origin/Referer are absent (typical for native/Expo clients), fall back to
+    the registry default app code so password auth and refresh still work.
     :param registry:
     :param required:
     :return:
@@ -23,6 +26,8 @@ def resolve_request_app_code(registry: MemberWebAppRegistry, *, required: bool =
         origin = req_ctx.headers.origin
         referer = req_ctx.headers.referer
     app_code = registry.resolve_app_code(origin=origin, referer=referer)
+    if not app_code:
+        app_code = registry.default_app_code
     if required and not app_code:
         raise ForbiddenException(detail="Unknown or missing web app Origin")
     return app_code

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -52,6 +52,7 @@ class RootContainer(containers.DeclarativeContainer):
 
     bible_service = app.bible_service
     end_user_provisioning_service = app.end_user_provisioning_service
+    app_auth_service = app.app_auth_service
 
     event_bus = events.event_bus
 

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -5,7 +5,10 @@ Member app application services.
 from dependency_injector import containers, providers
 
 from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.app_auth_service import AppAuthService
 from portal.application.bible.bible_service import BibleService
+from portal.config import settings as app_settings
+from portal.domain.auth.member_web_app import MemberWebAppRegistry, parse_member_web_apps
 from portal.infrastructure.persistence.repositories.app.end_user_repository import EndUserRepository, PreferencesRepository
 from portal.infrastructure.persistence.repositories.bible.bible_repository import BibleRepository
 from portal.infrastructure.persistence.repositories.user_repository import UserRepository
@@ -28,4 +31,18 @@ class AppContainer(containers.DeclarativeContainer):
         end_user_repository=end_user_repository,
         preferences_repository=preferences_repository,
         password_provider=core.password_provider,
+    )
+
+    member_web_app_registry = providers.Singleton(lambda: MemberWebAppRegistry(parse_member_web_apps(app_settings.MEMBER_WEB_APPS)))
+    app_auth_service = providers.Factory(
+        AppAuthService,
+        provisioning_service=end_user_provisioning_service,
+        user_repository=user_repository,
+        end_user_repository=end_user_repository,
+        preferences_repository=preferences_repository,
+        password_provider=core.password_provider,
+        jwt_provider=core.jwt_provider,
+        refresh_token_provider=core.refresh_token_provider,
+        member_refresh_app_binding_provider=core.member_refresh_app_binding_provider,
+        member_web_app_registry=member_web_app_registry,
     )

--- a/portal/domain/app/ports.py
+++ b/portal/domain/app/ports.py
@@ -2,7 +2,7 @@
 Ports for End user identity and Preferences persistence.
 """
 
-from typing import Protocol
+from typing import Optional, Protocol
 from uuid import UUID
 
 from portal.domain.app.entities import EndUser, UserPreferences
@@ -13,8 +13,12 @@ class EndUserRepositoryPort(Protocol):
 
     async def create_end_user(self, *, end_user_id: UUID, auth_user_id: UUID) -> EndUser: ...
 
+    async def get_by_auth_user_id(self, auth_user_id: UUID) -> Optional[EndUser]: ...
+
 
 class PreferencesRepositoryPort(Protocol):
     """Persist 1:1 Preferences for an End user."""
 
     async def create_preferences(self, preferences: UserPreferences) -> UserPreferences: ...
+
+    async def get_by_user_id(self, user_id: UUID) -> Optional[UserPreferences]: ...

--- a/portal/domain/auth/member_web_app.py
+++ b/portal/domain/auth/member_web_app.py
@@ -75,6 +75,11 @@ class MemberWebAppRegistry:
     def apps(self) -> list[MemberWebApp]:
         return list(self._apps)
 
+    @property
+    def default_app_code(self) -> Optional[str]:
+        """First registered member app code — fallback when Origin is absent (mobile)."""
+        return self._apps[0].code if self._apps else None
+
     def resolve_app_code(self, origin: Optional[str] = None, referer: Optional[str] = None) -> Optional[str]:
         """
         Resolve request Origin (preferred) or Referer to app_code.

--- a/portal/domain/auth/ports.py
+++ b/portal/domain/auth/ports.py
@@ -59,6 +59,8 @@ class UserRepositoryPort(Protocol):
 
     async def update_user_active_flag(self, user_id: UUID, is_active: bool) -> None: ...
 
-    async def create_credential(self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False) -> UUID:
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
         """Insert auth.user only (no AuthUserProfile, no app.user)."""
         ...

--- a/portal/infrastructure/persistence/repositories/app/end_user_repository.py
+++ b/portal/infrastructure/persistence/repositories/app/end_user_repository.py
@@ -2,6 +2,7 @@
 Repositories for End user provisioning under the app schema.
 """
 
+from typing import Optional
 from uuid import UUID
 
 from portal.domain.app.entities import EndUser, UserPreferences
@@ -10,7 +11,7 @@ from portal.models.app import AppUser, AppUserPreferences
 
 
 class EndUserRepository:
-    """Insert app.user End user rows."""
+    """Insert and load app.user End user rows."""
 
     def __init__(self, session: Session):
         self._session = session
@@ -19,9 +20,17 @@ class EndUserRepository:
         await self._session.insert(AppUser).values(id=end_user_id, auth_user_id=auth_user_id).execute()
         return EndUser(id=end_user_id, auth_user_id=auth_user_id)
 
+    async def get_by_auth_user_id(self, auth_user_id: UUID) -> Optional[EndUser]:
+        return await (
+            self._session.select(AppUser.id, AppUser.auth_user_id)
+            .where(AppUser.auth_user_id == auth_user_id)
+            .where(AppUser.is_deleted == False)
+            .fetchrow(as_model=EndUser)
+        )
+
 
 class PreferencesRepository:
-    """Insert app.user_preferences rows."""
+    """Insert and load app.user_preferences rows."""
 
     def __init__(self, session: Session):
         self._session = session
@@ -44,3 +53,21 @@ class PreferencesRepository:
             .execute()
         )
         return preferences
+
+    async def get_by_user_id(self, user_id: UUID) -> Optional[UserPreferences]:
+        return await (
+            self._session.select(
+                AppUserPreferences.id,
+                AppUserPreferences.user_id,
+                AppUserPreferences.display_name,
+                AppUserPreferences.locale,
+                AppUserPreferences.theme,
+                AppUserPreferences.font_scale,
+                AppUserPreferences.bible_version,
+                AppUserPreferences.stage,
+                AppUserPreferences.reminder_time,
+                AppUserPreferences.reminder_enabled,
+            )
+            .where(AppUserPreferences.user_id == user_id)
+            .fetchrow(as_model=UserPreferences)
+        )

--- a/portal/infrastructure/persistence/repositories/user_repository.py
+++ b/portal/infrastructure/persistence/repositories/user_repository.py
@@ -28,6 +28,7 @@ class UserRepository:
         self._session = session
 
     async def get_detail_by_id(self, user_id: UUID) -> Optional[UserDetail]:
+        # Outer join: End users have auth.user without AuthUserProfile (ADR 0004).
         user: UserDetail = await (
             self._session.select(
                 AuthUser.id,
@@ -42,7 +43,7 @@ class UserRepository:
                 AuthUserProfile.last_name,
                 AuthUserProfile.gender,
             )
-            .join(AuthUserProfile, AuthUser.id == AuthUserProfile.user_id)
+            .outerjoin(AuthUserProfile, AuthUser.id == AuthUserProfile.user_id)
             .where(AuthUser.id == user_id)
             .where(AuthUser.is_deleted == False)
             .fetchrow(as_model=UserDetail)
@@ -69,7 +70,7 @@ class UserRepository:
                 AuthUserProfile.preferred_locale_id,
                 AuthUserProfile.gender,
             )
-            .join(AuthUserProfile, AuthUser.id == AuthUserProfile.user_id)
+            .outerjoin(AuthUserProfile, AuthUser.id == AuthUserProfile.user_id)
             .where(AuthUser.id == user_id)
             .where(AuthUser.is_deleted == False)
             .fetchrow(as_model=UserSensitive)
@@ -307,13 +308,20 @@ class UserRepository:
             .fetchrow(as_model=AdminUserDetailResult)
         )
 
-    async def create_credential(self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False) -> UUID:
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
         """Insert auth.user credential only — no AuthUserProfile and no app.user."""
-        await (
-            self._session.insert(AuthUser)
-            .values(id=auth_user_id, email=email, password_hash=password_hash, verified=False, is_active=True, is_admin=is_admin, is_superuser=is_superuser)
-            .execute()
-        )
+        try:
+            await (
+                self._session.insert(AuthUser)
+                .values(
+                    id=auth_user_id, email=email, password_hash=password_hash, verified=verified, is_active=True, is_admin=is_admin, is_superuser=is_superuser
+                )
+                .execute()
+            )
+        except UniqueViolationError as error:
+            raise ConflictErrorException(detail="User already exists", error_code=AuthErrorCode.USER_ALREADY_EXISTS.value, debug_detail=str(error))
         return auth_user_id
 
     async def create_user(self, user_id: UUID, model: CreateAdminUserCommand, password_hash: str) -> CreateIdResult:

--- a/portal/routers/apis/v1/__init__.py
+++ b/portal/routers/apis/v1/__init__.py
@@ -1,11 +1,13 @@
 """
 v1 API router
 """
+
 from fastapi import APIRouter
 
+from .auth import router as auth_router
 from .bible import router as bible_router
 
 router = APIRouter()
 
+router.include_router(auth_router, prefix="/auth", tags=["Auth"])
 router.include_router(bible_router, prefix="/bible", tags=["Bible"])
-

--- a/portal/routers/apis/v1/auth.py
+++ b/portal/routers/apis/v1/auth.py
@@ -1,0 +1,45 @@
+"""
+App (End user) authentication HTTP routes.
+"""
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends, status
+
+from portal.application.auth.app_auth_service import AppAuthService
+from portal.application.auth.commands import AppLoginCommand, AppRegisterCommand, LogoutCommand, RefreshTokenCommand
+from portal.application.auth.mappers import member_login_result_to_api, token_result_to_api
+from portal.application.auth.refresh_token_service import RefreshTokenService
+from portal.container import Container
+from portal.routers.auth_router import AuthRouter
+from portal.serializers.apis.v1.auth import MemberLoginRequest, MemberLoginResponse, MemberRegisterRequest
+from portal.serializers.mixins import LogoutRequest, LogoutResponse, RefreshTokenRequest, TokenResponse
+
+router: AuthRouter = AuthRouter()
+
+
+@router.post("/register", response_model=MemberLoginResponse, response_model_by_alias=True, status_code=status.HTTP_200_OK, require_auth=False)
+@inject
+async def app_register(body: MemberRegisterRequest, app_auth_service: AppAuthService = Depends(Provide[Container.app_auth_service])):
+    result = await app_auth_service.register(AppRegisterCommand(email=body.email, password=body.password, display_name=body.display_name))
+    return member_login_result_to_api(result)
+
+
+@router.post("/login", response_model=MemberLoginResponse, response_model_by_alias=True, status_code=status.HTTP_200_OK, require_auth=False)
+@inject
+async def app_login(body: MemberLoginRequest, app_auth_service: AppAuthService = Depends(Provide[Container.app_auth_service])):
+    result = await app_auth_service.login(AppLoginCommand(email=body.email, password=body.password))
+    return member_login_result_to_api(result)
+
+
+@router.post("/refresh", response_model=TokenResponse, response_model_by_alias=True, require_auth=False)
+@inject
+async def app_refresh_token(body: RefreshTokenRequest, refresh_token_service: RefreshTokenService = Depends(Provide[Container.refresh_token_service])):
+    result = await refresh_token_service.refresh_member_token(RefreshTokenCommand(refresh_token=body.refresh_token))
+    return token_result_to_api(result)
+
+
+@router.post("/logout", response_model=LogoutResponse, response_model_by_alias=True, require_auth=False)
+@inject
+async def app_logout(body: LogoutRequest, refresh_token_service: RefreshTokenService = Depends(Provide[Container.refresh_token_service])):
+    await refresh_token_service.logout_member(LogoutCommand(access_token=body.access_token, refresh_token=body.refresh_token))
+    return LogoutResponse(message="Logged out")

--- a/portal/serializers/apis/v1/auth.py
+++ b/portal/serializers/apis/v1/auth.py
@@ -12,8 +12,23 @@ from portal.domain.common.mixins import UUIDModel
 from portal.serializers.mixins import LoginResponse, TokenResponse
 
 
+class MemberRegisterRequest(BaseModel):
+    """End user password registration body."""
+
+    email: str = Field(..., description="End user email")
+    password: str = Field(..., description="End user password")
+    display_name: str = Field(..., description="Display name for Preferences")
+
+
+class MemberLoginRequest(BaseModel):
+    """End user password login body."""
+
+    email: str = Field(..., description="End user email")
+    password: str = Field(..., description="End user password")
+
+
 class MemberInfo(UUIDModel):
-    """Member profile for SPA responses."""
+    """End user profile for app auth responses."""
 
     email: str = Field(..., description="Member email")
     first_name: str = Field(..., description="First name")
@@ -25,12 +40,6 @@ class MemberInfo(UUIDModel):
 
 
 class MemberLoginResponse(LoginResponse):
-    """Member login response."""
+    """Member login / register response."""
 
-    member: MemberInfo = Field(..., description="Member info")
-
-
-class MicrosoftIdTokenRequest(BaseModel):
-    """Microsoft Entra ID token exchange body."""
-
-    id_token: str = Field(..., description="Microsoft ID token")
+    member: MemberInfo = Field(..., description="End user info (id is app.user.id)")

--- a/tests/application/app/test_end_user_provisioning_service.py
+++ b/tests/application/app/test_end_user_provisioning_service.py
@@ -27,8 +27,19 @@ class StubUserRepository:
     def __init__(self):
         self.created: list[dict] = []
 
-    async def create_credential(self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False) -> UUID:
-        self.created.append({"auth_user_id": auth_user_id, "email": email, "password_hash": password_hash, "is_admin": is_admin, "is_superuser": is_superuser})
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
+        self.created.append(
+            {
+                "auth_user_id": auth_user_id,
+                "email": email,
+                "password_hash": password_hash,
+                "is_admin": is_admin,
+                "is_superuser": is_superuser,
+                "verified": verified,
+            }
+        )
         return auth_user_id
 
 
@@ -86,6 +97,7 @@ async def test_register_end_user_creates_credential_end_user_and_preferences():
     assert user_repo.created[0]["email"] == "member@example.com"
     assert user_repo.created[0]["password_hash"] == "hashed:Secure1!"
     assert user_repo.created[0]["is_admin"] is False
+    assert user_repo.created[0]["verified"] is True
     assert result.auth_user_id == user_repo.created[0]["auth_user_id"]
 
     assert len(end_user_repo.created) == 1
@@ -115,6 +127,7 @@ async def test_admin_only_provision_skips_end_user_and_preferences():
 
     assert len(user_repo.created) == 1
     assert user_repo.created[0]["is_admin"] is True
+    assert user_repo.created[0]["verified"] is False
     assert result.auth_user_id == user_repo.created[0]["auth_user_id"]
     assert result.end_user_id is None
     assert end_user_repo.created == []

--- a/tests/application/auth/test_app_auth_service.py
+++ b/tests/application/auth/test_app_auth_service.py
@@ -1,0 +1,201 @@
+"""
+Application-service seam: End user register / login (stub ports).
+
+Happy path: register provisions credential + End user + Preferences and
+returns member tokens; login authenticates an existing End user.
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.application.auth.app_auth_service import AppAuthService
+from portal.application.auth.commands import AppLoginCommand, AppRegisterCommand
+from portal.application.auth.results import MemberLoginResult, TokenResult, UserSensitive
+from portal.domain.app.entities import EndUser, UserPreferences
+from portal.exceptions.responses import BadRequestException, UnauthorizedException
+
+
+class StubPasswordProvider:
+    def validate_password(self, password: str) -> bool:
+        return len(password) >= 8
+
+    def hash_password(self, password: str) -> str:
+        return f"hashed:{password}"
+
+    def verify_password(self, password: str, password_hash: str) -> bool:
+        return password_hash == f"hashed:{password}"
+
+
+class StubUserRepository:
+    def __init__(self):
+        self.by_email: dict[str, UserSensitive] = {}
+        self.last_login_updates: list[UUID] = []
+
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
+        user = UserSensitive(
+            id=auth_user_id,
+            email=email,
+            password_hash=password_hash,
+            verified=verified,
+            is_active=True,
+            is_admin=is_admin,
+            is_superuser=is_superuser,
+            first_name="",
+            last_name="",
+        )
+        self.by_email[email] = user
+        return auth_user_id
+
+    async def get_sensitive_by_email_without_profile(self, email: str):
+        return self.by_email.get(email.strip().lower())
+
+    async def update_last_login_at(self, user_id: UUID, last_login_at) -> None:
+        self.last_login_updates.append(user_id)
+
+
+class StubEndUserRepository:
+    def __init__(self):
+        self.by_auth_user_id: dict[UUID, EndUser] = {}
+
+    async def create_end_user(self, *, end_user_id: UUID, auth_user_id: UUID) -> EndUser:
+        end_user = EndUser(id=end_user_id, auth_user_id=auth_user_id)
+        self.by_auth_user_id[auth_user_id] = end_user
+        return end_user
+
+    async def get_by_auth_user_id(self, auth_user_id: UUID):
+        return self.by_auth_user_id.get(auth_user_id)
+
+
+class StubPreferencesRepository:
+    def __init__(self):
+        self.by_user_id: dict[UUID, UserPreferences] = {}
+
+    async def create_preferences(self, preferences: UserPreferences) -> UserPreferences:
+        self.by_user_id[preferences.user_id] = preferences
+        return preferences
+
+    async def get_by_user_id(self, user_id: UUID):
+        return self.by_user_id.get(user_id)
+
+
+class StubJwtProvider:
+    def create_access_token(self, *args, **kwargs) -> str:
+        return "access-token"
+
+
+class StubRefreshTokenProvider:
+    async def issue(self, *, user_id: UUID, device_id: UUID, family_id: UUID) -> str:
+        return "refresh-token"
+
+
+class StubMemberRefreshAppBindingProvider:
+    def __init__(self):
+        self.bound: list[tuple] = []
+
+    async def bind(self, family_id: UUID, app_code: str) -> None:
+        self.bound.append((family_id, app_code))
+
+
+class StubMemberWebAppRegistry:
+    def __init__(self, default_code: str = "rooted-app"):
+        self._default_code = default_code
+
+    @property
+    def default_app_code(self) -> str:
+        return self._default_code
+
+    def resolve_app_code(self, origin=None, referer=None):
+        return None
+
+
+def _build_service() -> tuple[AppAuthService, StubUserRepository, StubEndUserRepository, StubPreferencesRepository]:
+    from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+
+    user_repo = StubUserRepository()
+    end_user_repo = StubEndUserRepository()
+    prefs_repo = StubPreferencesRepository()
+    password = StubPasswordProvider()
+    provisioning = EndUserProvisioningService(
+        user_repository=user_repo, end_user_repository=end_user_repo, preferences_repository=prefs_repo, password_provider=password
+    )
+    service = AppAuthService(
+        provisioning_service=provisioning,
+        user_repository=user_repo,
+        end_user_repository=end_user_repo,
+        preferences_repository=prefs_repo,
+        password_provider=password,
+        jwt_provider=StubJwtProvider(),
+        refresh_token_provider=StubRefreshTokenProvider(),
+        member_refresh_app_binding_provider=StubMemberRefreshAppBindingProvider(),
+        member_web_app_registry=StubMemberWebAppRegistry(),
+    )
+    return service, user_repo, end_user_repo, prefs_repo
+
+
+@pytest.mark.asyncio
+async def test_register_creates_end_user_and_returns_tokens():
+    service, user_repo, end_user_repo, prefs_repo = _build_service()
+
+    result = await service.register(AppRegisterCommand(email="jay@example.com", password="Secure1!", display_name="Jay"))
+
+    assert isinstance(result, MemberLoginResult)
+    assert result.token.access_token == "access-token"
+    assert result.token.refresh_token == "refresh-token"
+    assert result.token.token_type == "bearer"
+    assert result.token.expires_in > 0
+
+    assert "jay@example.com" in user_repo.by_email
+    assert user_repo.by_email["jay@example.com"].verified is True
+    end_user = end_user_repo.by_auth_user_id[user_repo.by_email["jay@example.com"].id]
+    assert result.member.id == end_user.id
+    assert result.member.id != user_repo.by_email["jay@example.com"].id
+    assert result.member.email == "jay@example.com"
+    assert result.member.preferred_name == "Jay"
+    assert prefs_repo.by_user_id[end_user.id].display_name == "Jay"
+
+
+@pytest.mark.asyncio
+async def test_login_returns_tokens_for_existing_end_user():
+    service, user_repo, end_user_repo, prefs_repo = _build_service()
+    await service.register(AppRegisterCommand(email="jay@example.com", password="Secure1!", display_name="Jay"))
+
+    result = await service.login(AppLoginCommand(email="jay@example.com", password="Secure1!"))
+
+    assert result.token.access_token == "access-token"
+    assert result.member.email == "jay@example.com"
+    assert result.member.preferred_name == "Jay"
+    end_user = next(iter(end_user_repo.by_auth_user_id.values()))
+    assert result.member.id == end_user.id
+    assert user_repo.last_login_updates
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_wrong_password():
+    service, *_ = _build_service()
+    await service.register(AppRegisterCommand(email="jay@example.com", password="Secure1!", display_name="Jay"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login(AppLoginCommand(email="jay@example.com", password="WrongPass1"))
+
+
+@pytest.mark.asyncio
+async def test_login_rejects_credential_without_end_user():
+    service, user_repo, end_user_repo, _ = _build_service()
+    auth_user_id = uuid4()
+    await user_repo.create_credential(auth_user_id=auth_user_id, email="admin-only@example.com", password_hash="hashed:Secure1!", is_admin=True, verified=True)
+
+    with pytest.raises(UnauthorizedException):
+        await service.login(AppLoginCommand(email="admin-only@example.com", password="Secure1!"))
+    assert end_user_repo.by_auth_user_id == {}
+
+
+@pytest.mark.asyncio
+async def test_register_rejects_weak_password():
+    service, *_ = _build_service()
+
+    with pytest.raises(BadRequestException):
+        await service.register(AppRegisterCommand(email="jay@example.com", password="short", display_name="Jay"))


### PR DESCRIPTION
## Summary

Adds member `/api/v1/auth` register, login, refresh, and logout so rooted-app can obtain JWTs while the server provisions `auth.user` + End user (`app.user`) + Preferences. Closes #6.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `AppAuthService` owns password register/login; refresh/logout reuse shared member JWT providers.
- Response `member.id` is `app.user.id`; JWT `sub` remains `auth.user.id` (ADR 0004).
- App signup sets `verified=True`; credential loads use outerjoin so End users without `AuthUserProfile` work with middleware/refresh.
- Missing Origin (Expo / rooted-app) falls back to the first `MEMBER_WEB_APPS` code.
- No `alembic/versions/` changes.

## Testing

- [x] `uv run pytest`
- [x] `uv run pytest tests/application/auth/test_app_auth_service.py`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge