### PR TITLE
feat(auth): Identity link catalog and Auth credential reshape (#12)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ This document helps AI agents quickly understand the **Rooted Core API** codebas
 | **Framework**       | FastAPI (async)                                                                                            |
 | **Database**        | PostgreSQL + SQLAlchemy (asyncpg)                                                                          |
 | **Cache**           | Redis (sessions, rate limiting, auth blacklist when enabled)                                               |
-| **Auth (app)**      | JWT — email/password and optional magic link (see ADR 0003); **no** Microsoft Entra / OIDC in scope        |
-| **Auth (admin)**    | JWT + RBAC for admin console at `/admin`                                                                   |
+| **Auth (app)**      | JWT — passwordless magic link for End users (see ADR 0003); Identity link storage ADR 0005; **no** Microsoft Entra / OIDC in scope |
+| **Auth (admin)**    | JWT + RBAC — email/password for admin console at `/admin`                                                   |
 | **DI**              | `dependency-injector`                                                                                      |
 | **Package manager** | uv (`uv run …`)                                                                                            |
 | **Python**          | 3.14+ (see `pyproject.toml`)                                                                               |
@@ -146,7 +146,7 @@ Rooted v1 domains (from PRD and `rooted-docs`). Use these folder names when addi
 
 | Context    | Responsibility                                      |
 | ---------- | --------------------------------------------------- |
-| **auth**   | Register/login, refresh, magic link (optional), JWT |
+| **auth**   | Magic-link (passwordless) End-user auth, Admin password login, refresh, JWT; Identity links (ADR 0005) |
 | **users**  | Profile, preferences, account deletion              |
 | **sync**   | Client ↔ server sync for v1                         |
 | **reports**| User reports + moderation queue                     |
@@ -206,14 +206,16 @@ See ADR 0003.
 
 ### App users
 
-- Primary: **email + password** (NewLife-style admin parity for password hashing/JWT plumbing).
-- Product also specifies **magic link** endpoints for end users — implement alongside password, not instead of shared JWT infrastructure.
-- **Excluded:** Microsoft Entra ID token exchange, OIDC social login.
+- **Passwordless:** magic-link request/verify for End users (ADR 0003). Auth credentials may have `password_hash` null.
+- Shared JWT access/refresh infrastructure with Admin; product FKs hang off End user (`app.user`), not `auth.user` alone (ADR 0004).
+- Identity provider catalog + Identity link rows prepare Apple/Google storage (ADR 0005) — OAuth/OIDC HTTP flows are a future ADR.
+- **Excluded:** Microsoft Entra ID token exchange, app password register/login as the product path, phone-as-login-id.
 
 ### Admin
 
 1. `AuthMiddleware` validates Bearer JWT and loads admin user.
-2. RBAC via permissions on admin routes (see `portal/libs/consts/permission.py` pattern).
+2. RBAC via permissions on admin routes (see `portal.libs.consts.permission` pattern).
+3. Admin create/login remains **email + password** on the shared Auth credential.
 
 ### Auth levels (product)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -124,6 +124,18 @@ _Avoid_: Admin User profile fields, burying prefs inside fellowship or journal r
 Staff account using the **admin** API (`/admin`) for RBAC, content, and moderation — distinct from **shepherd** (group role) and from **End user**. May share the same auth credential as an End user when one person holds both capacities.
 _Avoid_: Operator, treating Membership role as admin
 
+**Auth credential**:
+The sign-in subject in `auth.user`, always identified by a required email, with optional password and zero or more **Identity links**. An **End user** and an **Admin User** may share one credential; product data hangs off **End user**, not off this row. Phone number is not part of this credential.
+_Avoid_: Account (ambiguous), conflating with **End user** / `app.user`, phone-as-login-id
+
+**Identity provider**:
+A known external sign-in source (e.g. Google, Apple, Microsoft) registered in the auth catalog — not the person’s account at that vendor, and not an OAuth token.
+_Avoid_: Social network, OAuth client, treating a free-form string as the provider without a catalog entry
+
+**Identity link**:
+A durable binding from an **Identity provider** subject (and optional provider tenant) to one **Auth credential**. One credential may have many links across providers; at most one active link per credential per provider; each provider subject binds to at most one credential. Used to recognize the same person on later sign-ins — not an OAuth token store and not a product profile.
+_Avoid_: OAuth session, social account, third-party login (as the noun for the row), storing provider access/refresh tokens as the purpose of this concept
+
 **Report**:
 User flag on fellowship content (prayer, share, etc.) with reason code — feeds moderation queue in v1.
 
@@ -150,4 +162,4 @@ Client ↔ server reconciliation for v1 accounts — not a second product surfac
 | PRD | `rooted-docs/docs/product/prd.md` |
 | API spec | `rooted-docs/docs/backend/api-specification.md` |
 | Database design | `rooted-docs/docs/backend/database-design.md` |
-| ADRs | `docs/adr/` |
+| ADRs | `docs/adr/` (auth identity storage: ADR 0005) |

--- a/docs/adr/0003-auth-strategy-newlife-password-first.md
+++ b/docs/adr/0003-auth-strategy-newlife-password-first.md
@@ -1,27 +1,31 @@
-# ADR 0003 — Auth strategy: NewLife-style password-first JWT (no Microsoft OIDC)
+# ADR 0003 — Auth strategy: Admin password-first; app End users passwordless (magic link)
 
 ## Status
 
-Accepted (Phase 0, 2026-08-27)
+Accepted (Phase 0, 2026-08-27); **updated** (2026-09-05) for app passwordless.
+
+Supersedes the earlier “app password + optional magic link” wording in this ADR. Durable Identity storage for future Apple/Google is ADR 0005 — this ADR does **not** authorize OIDC HTTP flows.
 
 ## Context
 
-Rooted v1 requires account-backed sync and fellowship (`rooted-docs` PRD §9.4, API spec §2). The codebase inherits JWT, password hashing, and admin RBAC patterns from the portal/NewLife lineage.
+Rooted requires account-backed sync and fellowship (`rooted-docs` PRD §9.4, API spec §2). The codebase inherits JWT, password hashing, and admin RBAC patterns from the portal/NewLife lineage.
 
-Product spec also describes **magic link** email login for end users. NewLife admin adds **Microsoft Entra ID** token exchange — that flow serves church staff SSO, not Rooted’s consumer devotional audience, and would add OIDC configuration and user-provisioning rules we do not need.
+Product direction for **End users** is **passwordless**: magic-link email login now; Apple/Google Identity links later (schema in ADR 0005). **Admin Users** still need email + password on the shared **Auth credential** table. NewLife’s Microsoft Entra ID token exchange serves church staff SSO — not Rooted’s consumer audience — and remains out of scope.
 
 ## Decision
 
-1. **Primary credential model (shared infrastructure):** email + **password** with JWT access and refresh tokens, implemented using the same provider patterns as NewLife (password hash, `JWTProvider`, refresh rotation/blacklist as enabled).
-2. **Admin Users** authenticate via admin login endpoints under `/admin/api/v1/auth` with RBAC — password-first; no Microsoft/OIDC login for Rooted admin in v1.
-3. **App end users** expose password registration/login **and** magic-link endpoints per `rooted-docs/docs/backend/api-specification.md`; magic link is an additional factorless channel, not a separate auth stack.
-4. **Explicitly out of scope:** Microsoft Entra ID / Azure AD token exchange, generic OIDC social login, and NewLife-style `MicrosoftAuthService`.
-5. **Token policy:** follow product ranges (access ~15–60 minutes, refresh ~7–30 days) via configuration; clients send `Authorization: Bearer`.
-6. **Anonymous access:** allow unauthenticated reads where the API spec marks devotion/bible as client-first; fellowship and journal require member JWT.
+1. **Shared infrastructure:** JWT access + refresh tokens, password hashing providers, and refresh rotation/blacklist as enabled — same plumbing for Admin and (when issued) member tokens.
+2. **Admin Users** authenticate via `/admin/api/v1/auth` with **email + password** and RBAC. No Microsoft/OIDC login for Rooted admin.
+3. **App End users** authenticate via **magic link only** (request + verify). Do **not** expose app password register/login as the product path. Magic-link verify may create an Auth credential with `password_hash` null plus End user + Preferences.
+4. **Auth credential:** required email; optional password (required for Admin create/login); zero or more Identity links (ADR 0005). Phone is not a credential identifier.
+5. **Explicitly out of scope:** Microsoft Entra / Azure AD token exchange, generic OIDC social login, and NewLife-style `MicrosoftAuthService`. Enabling Apple/Google HTTP flows requires a future ADR on top of ADR 0005 storage.
+6. **Token policy:** follow product ranges (access ~15–60 minutes, refresh ~7–30 days) via configuration; clients send `Authorization: Bearer`.
+7. **Anonymous access:** allow unauthenticated reads where the API spec marks devotion/bible as client-first; fellowship and journal require member JWT.
 
 ## Consequences
 
 - No OIDC client secrets or Entra app registration in Rooted deployments.
-- Auth application services live under `portal/application/auth/` as migration proceeds; legacy middleware remains until routers delegate to services.
-- Magic link implementation must reuse the same user records and JWT issuance as password login.
+- Agents must not reintroduce app password register/login as the primary End-user path.
+- Admin password create/login must keep working on the same `auth.user` rows End users use (shared credential; ADR 0004).
+- Magic-link token storage is ephemeral (e.g. Redis TTL), not on Identity link rows.
 - If enterprise SSO is ever required, it demands a new ADR — it is not a silent port from `newlife-core-api`.

--- a/docs/adr/0005-identity-link-and-provider-catalog.md
+++ b/docs/adr/0005-identity-link-and-provider-catalog.md
@@ -45,3 +45,4 @@ We need a table design that can hold most third-party sign-in bindings before th
 - Repository ports that upsert by `provider_uid` / UUID tenant must move to `provider_subject` + nullable `provider_tenant`.
 - `ThirdPartyProvider` / Microsoft leftovers stay dead until a sign-in ADR; catalog codes are the source of truth for allowed providers.
 - Implementing Apple or Google login is still a separate ADR and must not be inferred from this schema alone.
+- Human Alembic steps: see `docs/migrations/0005-identity-link-alembic-checklist.md`.

--- a/docs/adr/0005-identity-link-and-provider-catalog.md
+++ b/docs/adr/0005-identity-link-and-provider-catalog.md
@@ -1,0 +1,47 @@
+# ADR 0005 — Identity link + Identity provider catalog (replace `user_third_party`)
+
+## Status
+
+Accepted (2026-09-04)
+
+Supersedes ADR 0004’s retention of NewLife-shaped `auth.user_third_party` as the forward model. Does **not** supersede ADR 0003: enabling Apple/Google (or any IdP) sign-in still needs its own product/implementation ADR; this decision only reshapes durable identity storage.
+
+## Context
+
+PRD schedules Apple / Google sign-in for v2. The ORM still mirrors NewLife: `auth.user_third_party` with required UUID `provider_tenant_id`, optional OAuth `access_token` / `refresh_token`, and a unique key of `(user_id, provider, provider_uid)` that does not globally uniquify a provider subject. That shape fits Microsoft Entra and token caching — not consumer IdPs and not an **Identity link**.
+
+We need a table design that can hold most third-party sign-in bindings before those flows are implemented, without reviving Microsoft OIDC in Rooted.
+
+## Decision
+
+1. **Ubiquitous language** (see `CONTEXT.md`): **Identity provider** (catalog entry) and **Identity link** (binding to an **Auth credential**). Links hang on `auth.user`, not `app.user`.
+
+2. **Replace** `auth.user_third_party` / `AuthUserThirdParty` with:
+   - **`auth.identity_provider`**: `code` (string PK, e.g. `google`, `apple`), English `name`, `is_active`, `requires_tenant`. No soft-delete; deactivate with `is_active`. Seed **`google`** and **`apple`** only (not `microsoft`).
+   - **`auth.identity_link`**: `user_id` → `auth.user`, `provider` → `identity_provider.code`, nullable string `provider_tenant`, `provider_subject`, optional `additional_data` (JSONB snapshot only), soft-delete + audit. **No** provider OAuth access/refresh token columns.
+
+3. **Cardinality / uniqueness** (active rows only, partial unique indexes; `NULL` tenants compare equal, e.g. `UNIQUE NULLS NOT DISTINCT` or equivalent):
+   - Global: `(provider, provider_tenant, provider_subject)` → at most one credential.
+   - Per credential: `(user_id, provider)` → many providers allowed; the same provider must not repeat.
+
+4. **Auth credential shape**: `email` is **NOT NULL**; drop `phone_number`. No email-less `auth.user` rows. Account-merge when the same email arrives via a new IdP is **out of scope** (no pending-merge table); decide in a future sign-in ADR.
+
+5. **Out of scope here**: OAuth/OIDC HTTP flows, token exchange, auto-link-by-email product rules, and Microsoft / church SSO (still ADR 0003 + a future ADR if needed).
+
+## Considered options
+
+| Topic | Rejected | Why |
+| ----- | -------- | --- |
+| Keep NewLife `user_third_party` + UUID tenant | Minimal diff | Blocks Apple/Google; wrong uniqueness; implies Entra |
+| Store OAuth tokens on the link row | Convenient for Graph APIs | Not the purpose of an Identity link; `String(255)` unfit; use a later token store if needed |
+| Provider as app enum only (no catalog) | Lighter schema | Rejected in favor of an explicit catalog for active flags and `requires_tenant` |
+| Soft-delete providers | Consistency with other auth tables | Stable codes + FK; `is_active` is enough |
+| Seed `microsoft` in the catalog | Symmetry with NewLife | Contradicts ADR 0003 signal; add only when SSO is approved |
+| Pending account-merge table now | Forward-looking | No users yet; merge policy undecided |
+
+## Consequences
+
+- ORM and human-owned Alembic should introduce `identity_provider` / `identity_link` and adjust `auth.user` (`email` NOT NULL, drop `phone_number`); remove or stop using `user_third_party` and token columns.
+- Repository ports that upsert by `provider_uid` / UUID tenant must move to `provider_subject` + nullable `provider_tenant`.
+- `ThirdPartyProvider` / Microsoft leftovers stay dead until a sign-in ADR; catalog codes are the source of truth for allowed providers.
+- Implementing Apple or Google login is still a separate ADR and must not be inferred from this schema alone.

--- a/docs/migrations/0005-identity-link-alembic-checklist.md
+++ b/docs/migrations/0005-identity-link-alembic-checklist.md
@@ -1,0 +1,38 @@
+# Human Alembic checklist — Identity link + Auth credential (#12 / ADR 0005)
+
+Agents must **not** add, modify, or delete files under `alembic/versions/`. A human should generate and review the migration.
+
+## Goals
+
+1. Adjust `auth.user` (Auth credential).
+2. Replace `auth.user_third_party` with `auth.identity_provider` + `auth.identity_link`.
+3. Seed Identity providers `google` and `apple` only (not `microsoft`).
+
+## Suggested steps
+
+1. **Backup / note local data:** any rows with null `email` or phone-only identifiers must be cleaned before `email` becomes `NOT NULL`. Empty production user base is assumed; local DBs may still need a one-off fix.
+2. **Autogenerate** (or hand-write) a revision after ORM changes are on the branch:
+   - `uv run alembic revision --autogenerate -m "identity_link_and_auth_credential"`
+3. **Review the revision** for at least:
+   - `auth.user.email` → `NOT NULL` (and unique retained)
+   - Drop `auth.user.phone_number` (column + unique index/constraint)
+   - Create `auth.identity_provider` (`code` PK, `name`, `is_active`, `requires_tenant`) — **no** UUID `id`, **no** soft-delete
+   - Create `auth.identity_link` with FK `user_id` → `auth.user`, FK `provider` → `auth.identity_provider.code`, nullable `provider_tenant`, `provider_subject`, optional `additional_data` JSONB, soft-delete + audit columns
+   - **No** OAuth `access_token` / `refresh_token` / `token_expires_at` on Identity link
+   - Partial unique indexes on **active** rows only (`is_deleted IS false`):
+     - `(provider, provider_tenant, provider_subject)` with `NULLS NOT DISTINCT` (or equivalent)
+     - `(user_id, provider)`
+   - Drop `auth.user_third_party` (or equivalent NewLife table) if present
+4. **Seed catalog** (migration `op.bulk_insert` **or** CLI after upgrade):
+   - `google` — name `Google`, `is_active=true`, `requires_tenant=false`
+   - `apple` — name `Apple`, `is_active=true`, `requires_tenant=false`
+   - Do **not** seed `microsoft`
+   - CLI alternative after tables exist: `uv run python -m portal.cli.main seed-identity-providers`
+5. **Apply locally:** `uv run alembic upgrade head`
+6. **Smoke:** Admin password create/login still works; `create_credential` with `password_hash=None` inserts; Identity link upsert/lookup against seeded providers.
+
+## Out of scope for this migration
+
+- Magic-link Redis/token tables
+- Apple/Google OAuth client config
+- Account-merge / pending-link tables

--- a/portal/application/auth/results.py
+++ b/portal/application/auth/results.py
@@ -75,7 +75,6 @@ class UserDetail(UUIDBaseModel):
     is_active: bool = Field(default=True, description="Whether the user is active")
     is_superuser: bool = Field(default=False, description="Whether the user is a superuser")
     is_admin: bool = Field(default=False, description="Whether the user can access admin portal")
-    phone_number: Optional[str] = Field(default=None, description="User phone number")
     last_login_at: Optional[datetime] = Field(default=None, description="Last login timestamp")
     first_name: Optional[str] = Field(default=None, description="First name")
     last_name: Optional[str] = Field(default=None, description="Last name")

--- a/portal/application/cli/identity_provider_seed_service.py
+++ b/portal/application/cli/identity_provider_seed_service.py
@@ -1,0 +1,33 @@
+"""
+Identity provider catalog seed use case for CLI (insert-if-missing).
+"""
+
+import click
+
+from portal.libs.database import Session
+from portal.libs.logger import logger
+from portal.models import AuthIdentityProvider
+
+
+class IdentityProviderSeedService:
+    """Insert Identity provider catalog rows when code is absent; never overwrite."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    async def run(self, seed_rows: list[dict]) -> int:
+        inserted = 0
+        for row in seed_rows:
+            existing = await self._session.select(AuthIdentityProvider.code).where(AuthIdentityProvider.code == row["code"]).fetchval()
+            if existing:
+                continue
+            await (
+                self._session.insert(AuthIdentityProvider)
+                .values(code=row["code"], name=row["name"], is_active=row["is_active"], requires_tenant=row["requires_tenant"])
+                .execute()
+            )
+            inserted += 1
+        await self._session.commit()
+        click.echo(click.style(f"Identity providers seeded. inserted={inserted} skipped={len(seed_rows) - inserted}", fg="bright_green"))
+        logger.info("Identity provider seed completed. inserted=%s skipped=%s", inserted, len(seed_rows) - inserted)
+        return inserted

--- a/portal/application/rbac/commands.py
+++ b/portal/application/rbac/commands.py
@@ -139,7 +139,6 @@ class AdminUserPagesQueryCommand(PagesQueryCommand):
 class CreateAdminUserCommand(BaseModel):
     """Create admin user command."""
 
-    phone_number: Optional[str] = Field(default=None)
     email: str = Field(...)
     verified: bool = Field(default=False)
     is_active: bool = Field(default=True)
@@ -155,7 +154,6 @@ class CreateAdminUserCommand(BaseModel):
 class UpdateAdminUserCommand(BaseModel):
     """Update admin user command."""
 
-    phone_number: Optional[str] = Field(default=None)
     email: str = Field(...)
     verified: bool = Field(default=False)
     is_active: bool = Field(default=True)

--- a/portal/application/rbac/mappers.py
+++ b/portal/application/rbac/mappers.py
@@ -190,7 +190,6 @@ def resource_list_query_to_command(model: DeleteQueryBaseModel) -> ResourceListQ
 
 def create_admin_user_to_command(model: AdminUserCreate) -> CreateAdminUserCommand:
     return CreateAdminUserCommand(
-        phone_number=model.phone_number,
         email=model.email,
         verified=model.verified,
         is_active=model.is_active,
@@ -206,7 +205,6 @@ def create_admin_user_to_command(model: AdminUserCreate) -> CreateAdminUserComma
 
 def update_admin_user_to_command(model: AdminUserUpdate) -> UpdateAdminUserCommand:
     return UpdateAdminUserCommand(
-        phone_number=model.phone_number,
         email=model.email,
         verified=model.verified,
         is_active=model.is_active,

--- a/portal/application/rbac/results.py
+++ b/portal/application/rbac/results.py
@@ -71,7 +71,6 @@ class ResourceTreeResult(BaseModel):
 class AdminUserListItem(UUIDBaseModel):
     """Admin user list row."""
 
-    phone_number: Optional[str] = Field(default=None)
     email: Optional[str] = Field(default=None)
     display_name: Optional[str] = Field(default=None)
 
@@ -79,7 +78,6 @@ class AdminUserListItem(UUIDBaseModel):
 class AdminUserTableRow(UUIDBaseModel):
     """Admin user table row."""
 
-    phone_number: Optional[str] = Field(default=None)
     email: Optional[str] = Field(default=None)
     verified: bool = Field(default=False)
     is_active: bool = Field(default=True)

--- a/portal/cli/datas/identity_provider_seed_data.py
+++ b/portal/cli/datas/identity_provider_seed_data.py
@@ -1,0 +1,6 @@
+"""Identity provider catalog seed rows (google + apple only)."""
+
+seed_identity_providers: list[dict] = [
+    {"code": "google", "name": "Google", "is_active": True, "requires_tenant": False},
+    {"code": "apple", "name": "Apple", "is_active": True, "requires_tenant": False},
+]

--- a/portal/cli/main.py
+++ b/portal/cli/main.py
@@ -1,10 +1,12 @@
 """
 CLI main entry point
 """
+
 import click
 
 from .bible import dump_bible_process
 from .import_bible import import_bible_data_process
+from .seed_identity_providers import seed_identity_providers_process
 
 
 @click.group()
@@ -23,15 +25,7 @@ def cli():
 @click.option("--include-notes", default=False, is_flag=True, help="Passages include_notes=true")
 @click.option("--meta-only", is_flag=True, help="Only fetch bible/index, not passages")
 def dump_bible_cmd(
-    bible_id: str,
-    out: str,
-    daily_limit: int,
-    sleep: float,
-    timeout: float,
-    format_: str,
-    include_headings: bool,
-    include_notes: bool,
-    meta_only: bool,
+    bible_id: str, out: str, daily_limit: int, sleep: float, timeout: float, format_: str, include_headings: bool, include_notes: bool, meta_only: bool
 ):
     """Dump YouVersion Bible metadata + passages with resume support.
 
@@ -64,7 +58,12 @@ def import_bible_cmd(bible_id: str, data_dir: str):
     import_bible_data_process(bible_id=bible_id, data_dir=data_dir)
 
 
+@cli.command(name="seed-identity-providers")
+def seed_identity_providers_cmd():
+    """Seed auth.identity_provider catalog (google + apple only; insert-if-missing)."""
+    seed_identity_providers_process()
+
+
 def main() -> int:
     cli()
     return 0
-

--- a/portal/cli/seed_identity_providers.py
+++ b/portal/cli/seed_identity_providers.py
@@ -1,0 +1,33 @@
+"""
+Identity provider catalog seed CLI.
+"""
+
+import asyncio
+
+import click
+
+from portal.application.cli.identity_provider_seed_service import IdentityProviderSeedService
+from portal.cli.datas.identity_provider_seed_data import seed_identity_providers
+from portal.container import Container
+from portal.libs.logger import logger
+
+
+async def seed_identity_providers_async() -> None:
+    """Seed auth.identity_provider rows (insert-if-missing)."""
+    container = Container()
+    session = container.db_session()
+    try:
+        service = IdentityProviderSeedService(session)
+        await service.run(seed_identity_providers)
+    except Exception as e:
+        await session.rollback()
+        click.echo(click.style(f"Identity provider seed failed: {e}", fg="red"))
+        logger.exception(e)
+        raise
+    finally:
+        await session.close()
+
+
+def seed_identity_providers_process() -> None:
+    """Synchronous entry for Identity provider seed."""
+    asyncio.run(seed_identity_providers_async())

--- a/portal/domain/auth/entities.py
+++ b/portal/domain/auth/entities.py
@@ -20,7 +20,6 @@ class User(UUIDModel):
     is_active: bool = Field(default=True, description="Whether the user is active")
     is_superuser: bool = Field(default=False, description="Whether the user is a superuser")
     is_admin: bool = Field(default=False, description="Whether the user can access admin portal")
-    phone_number: Optional[str] = Field(default=None, description="User phone number")
     last_login_at: Optional[datetime] = Field(default=None, description="Last login timestamp")
     first_name: Optional[str] = Field(default=None, description="First name")
     last_name: Optional[str] = Field(default=None, description="Last name")

--- a/portal/domain/auth/ports.py
+++ b/portal/domain/auth/ports.py
@@ -2,12 +2,10 @@
 Auth domain ports.
 """
 
-from datetime import datetime
 from typing import Any, Optional, Protocol
 from uuid import UUID
 
 from portal.application.auth.results import UserDetail, UserSensitive
-from portal.libs.consts.enums import ThirdPartyProvider
 
 
 class UserRepositoryPort(Protocol):
@@ -27,19 +25,13 @@ class UserRepositoryPort(Protocol):
 
     async def update_last_login_at(self, user_id: UUID, last_login_at) -> None: ...
 
-    async def upsert_auth_user_third_party(
-        self,
-        user_id: UUID,
-        provider: ThirdPartyProvider,
-        provider_uid: str,
-        provider_tenant_id: UUID,
-        additional_data: dict[str, Any],
-        token_expires_at: Optional[datetime] = None,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]: ...
+
+    async def upsert_identity_link(
+        self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
     ) -> None: ...
 
-    async def get_user_id_by_third_party(self, provider: ThirdPartyProvider, provider_uid: str) -> Optional[UUID]: ...
+    async def soft_delete_identity_link(self, user_id: UUID, provider: str) -> None: ...
 
     async def create_directory_user(
         self,
@@ -60,7 +52,7 @@ class UserRepositoryPort(Protocol):
     async def update_user_active_flag(self, user_id: UUID, is_active: bool) -> None: ...
 
     async def create_credential(
-        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+        self, *, auth_user_id: UUID, email: str, password_hash: Optional[str], is_admin: bool, is_superuser: bool = False, verified: bool = False
     ) -> UUID:
-        """Insert auth.user only (no AuthUserProfile, no app.user)."""
+        """Insert auth.user only (no AuthUserProfile, no app.user). password_hash may be null for passwordless End users."""
         ...

--- a/portal/infrastructure/persistence/repositories/user_repository.py
+++ b/portal/infrastructure/persistence/repositories/user_repository.py
@@ -129,16 +129,19 @@ class UserRepository:
         profile_id = await self._session.select(AuthUserProfile.id).where(AuthUserProfile.user_id == user_id).fetchval()
         return bool(profile_id)
 
-    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
-        query = (
-            self._session.select(AuthIdentityLink.user_id)
+    def _active_identity_link_by_subject(self, provider: str, provider_subject: str, provider_tenant: Optional[str]):
+        return (
+            self._session.select(AuthIdentityLink.id, AuthIdentityLink.user_id)
             .where(AuthIdentityLink.provider == provider)
             .where(AuthIdentityLink.provider_subject == provider_subject)
             .where(AuthIdentityLink.is_deleted == False)
             .where(provider_tenant is None, lambda: AuthIdentityLink.provider_tenant.is_(None))
             .where(provider_tenant is not None, lambda: AuthIdentityLink.provider_tenant == provider_tenant)
         )
-        return await query.fetchval()
+
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
+        row = await self._active_identity_link_by_subject(provider, provider_subject, provider_tenant).fetchrow()
+        return row["user_id"] if row else None
 
     async def create_directory_user(
         self,
@@ -425,20 +428,15 @@ class UserRepository:
         self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
     ) -> None:
         now = datetime.now(timezone.utc)
-        existing_id = await (
-            self._session.select(AuthIdentityLink.id)
-            .where(AuthIdentityLink.provider == provider)
-            .where(AuthIdentityLink.provider_subject == provider_subject)
-            .where(AuthIdentityLink.is_deleted == False)
-            .where(provider_tenant is None, lambda: AuthIdentityLink.provider_tenant.is_(None))
-            .where(provider_tenant is not None, lambda: AuthIdentityLink.provider_tenant == provider_tenant)
-            .fetchval()
-        )
-        if existing_id:
+        existing = await self._active_identity_link_by_subject(provider, provider_subject, provider_tenant).fetchrow()
+        if existing:
+            if existing["user_id"] != user_id:
+                # Preserve active uniqueness of (user_id, provider) when reassigning a subject.
+                await self.soft_delete_identity_link(user_id, provider)
             await (
                 self._session.update(AuthIdentityLink)
                 .values(user_id=user_id, additional_data=additional_data, updated_at=now, updated_by="identity_link")
-                .where(AuthIdentityLink.id == existing_id)
+                .where(AuthIdentityLink.id == existing["id"])
                 .execute()
             )
             return

--- a/portal/infrastructure/persistence/repositories/user_repository.py
+++ b/portal/infrastructure/persistence/repositories/user_repository.py
@@ -2,8 +2,6 @@
 User repository implementation (merged UserHandler + AdminUserHandler SQL).
 """
 
-import json
-import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID, uuid4
@@ -16,9 +14,9 @@ from portal.application.rbac.commands import AdminUserPagesQueryCommand, CreateA
 from portal.application.rbac.results import AdminUserDetailResult, AdminUserListItem, AdminUserTableRow, CreateIdResult
 from portal.domain.auth.constants import AuthErrorCode
 from portal.exceptions.responses import ConflictErrorException
-from portal.libs.consts.enums import Gender, ThirdPartyProvider
+from portal.libs.consts.enums import Gender
 from portal.libs.database import Session
-from portal.models import AuthUser, AuthUserProfile, AuthUserRole, AuthUserThirdParty, SystemLocale
+from portal.models import AuthIdentityLink, AuthUser, AuthUserProfile, AuthUserRole, SystemLocale
 
 
 class UserRepository:
@@ -32,7 +30,6 @@ class UserRepository:
         user: UserDetail = await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.verified,
                 AuthUser.is_active,
@@ -54,7 +51,6 @@ class UserRepository:
         user: UserSensitive = await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.password_hash,
                 AuthUser.verified,
@@ -84,7 +80,6 @@ class UserRepository:
         user: UserSensitive = await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.password_hash,
                 AuthUser.verified,
@@ -114,7 +109,6 @@ class UserRepository:
         user: UserSensitive = await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.password_hash,
                 AuthUser.verified,
@@ -135,15 +129,16 @@ class UserRepository:
         profile_id = await self._session.select(AuthUserProfile.id).where(AuthUserProfile.user_id == user_id).fetchval()
         return bool(profile_id)
 
-    async def get_user_id_by_third_party(self, provider: ThirdPartyProvider, provider_uid: str) -> Optional[UUID]:
-        user_id = await (
-            self._session.select(AuthUserThirdParty.user_id)
-            .where(AuthUserThirdParty.provider == provider.value)
-            .where(AuthUserThirdParty.provider_uid == provider_uid)
-            .where(AuthUserThirdParty.is_deleted == False)
-            .fetchval()
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
+        query = (
+            self._session.select(AuthIdentityLink.user_id)
+            .where(AuthIdentityLink.provider == provider)
+            .where(AuthIdentityLink.provider_subject == provider_subject)
+            .where(AuthIdentityLink.is_deleted == False)
+            .where(provider_tenant is None, lambda: AuthIdentityLink.provider_tenant.is_(None))
+            .where(provider_tenant is not None, lambda: AuthIdentityLink.provider_tenant == provider_tenant)
         )
-        return user_id
+        return await query.fetchval()
 
     async def create_directory_user(
         self,
@@ -222,7 +217,6 @@ class UserRepository:
         items, count = await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.verified,
                 AuthUser.is_active,
@@ -242,7 +236,6 @@ class UserRepository:
             .where(
                 model.keyword,
                 lambda: sa.or_(
-                    AuthUser.phone_number.ilike(f"%{model.keyword}%"),
                     AuthUser.email.ilike(f"%{model.keyword}%"),
                     AuthUserProfile.first_name.ilike(f"%{model.keyword}%"),
                     AuthUserProfile.last_name.ilike(f"%{model.keyword}%"),
@@ -263,12 +256,11 @@ class UserRepository:
 
     async def get_user_list(self, keyword: Optional[str] = None) -> list[AdminUserListItem]:
         users: list[AdminUserListItem] = await (
-            self._session.select(AuthUser.id, AuthUser.phone_number, AuthUser.email, AuthUserProfile.preferred_name.label("display_name"))
+            self._session.select(AuthUser.id, AuthUser.email, AuthUserProfile.preferred_name.label("display_name"))
             .join(AuthUserProfile, AuthUser.id == AuthUserProfile.user_id)
             .where(
                 keyword,
                 lambda: sa.or_(
-                    AuthUser.phone_number.ilike(f"%{keyword}%"),
                     AuthUser.email.ilike(f"%{keyword}%"),
                     AuthUserProfile.preferred_name.ilike(f"%{keyword}%"),
                     AuthUserProfile.first_name.ilike(f"%{keyword}%"),
@@ -287,7 +279,6 @@ class UserRepository:
         return await (
             self._session.select(
                 AuthUser.id,
-                AuthUser.phone_number,
                 AuthUser.email,
                 AuthUser.verified,
                 AuthUser.is_active,
@@ -309,7 +300,7 @@ class UserRepository:
         )
 
     async def create_credential(
-        self, *, auth_user_id: UUID, email: str, password_hash: str, is_admin: bool, is_superuser: bool = False, verified: bool = False
+        self, *, auth_user_id: UUID, email: str, password_hash: Optional[str], is_admin: bool, is_superuser: bool = False, verified: bool = False
     ) -> UUID:
         """Insert auth.user credential only — no AuthUserProfile and no app.user."""
         try:
@@ -330,7 +321,6 @@ class UserRepository:
                 self._session.insert(AuthUser)
                 .values(
                     id=user_id,
-                    phone_number=model.phone_number,
                     email=model.email,
                     password_hash=password_hash,
                     verified=model.verified,
@@ -361,7 +351,6 @@ class UserRepository:
             await (
                 self._session.update(AuthUser)
                 .values(
-                    phone_number=model.phone_number,
                     email=model.email,
                     verified=model.verified,
                     is_active=model.is_active,
@@ -432,46 +421,72 @@ class UserRepository:
     async def update_last_login_at(self, user_id: UUID, last_login_at: datetime) -> None:
         await self._session.update(AuthUser).where(AuthUser.id == user_id).values(last_login_at=last_login_at).execute()
 
-    async def upsert_auth_user_third_party(
-        self,
-        user_id: UUID,
-        provider: ThirdPartyProvider,
-        provider_uid: str,
-        provider_tenant_id: UUID,
-        additional_data: dict[str, Any],
-        token_expires_at: Optional[datetime] = None,
-        access_token: Optional[str] = None,
-        refresh_token: Optional[str] = None,
+    async def upsert_identity_link(
+        self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
     ) -> None:
         now = datetime.now(timezone.utc)
-        row_id = uuid4()
-        serialized_additional_data = json.dumps(additional_data)
+        existing_id = await (
+            self._session.select(AuthIdentityLink.id)
+            .where(AuthIdentityLink.provider == provider)
+            .where(AuthIdentityLink.provider_subject == provider_subject)
+            .where(AuthIdentityLink.is_deleted == False)
+            .where(provider_tenant is None, lambda: AuthIdentityLink.provider_tenant.is_(None))
+            .where(provider_tenant is not None, lambda: AuthIdentityLink.provider_tenant == provider_tenant)
+            .fetchval()
+        )
+        if existing_id:
+            await (
+                self._session.update(AuthIdentityLink)
+                .values(user_id=user_id, additional_data=additional_data, updated_at=now, updated_by="identity_link")
+                .where(AuthIdentityLink.id == existing_id)
+                .execute()
+            )
+            return
+
+        per_user_id = await (
+            self._session.select(AuthIdentityLink.id)
+            .where(AuthIdentityLink.user_id == user_id)
+            .where(AuthIdentityLink.provider == provider)
+            .where(AuthIdentityLink.is_deleted == False)
+            .fetchval()
+        )
+        if per_user_id:
+            await (
+                self._session.update(AuthIdentityLink)
+                .values(
+                    provider_subject=provider_subject,
+                    provider_tenant=provider_tenant,
+                    additional_data=additional_data,
+                    updated_at=now,
+                    updated_by="identity_link",
+                )
+                .where(AuthIdentityLink.id == per_user_id)
+                .execute()
+            )
+            return
+
         await (
-            self._session.insert(AuthUserThirdParty)
+            self._session.insert(AuthIdentityLink)
             .values(
-                id=row_id,
+                id=uuid4(),
                 user_id=user_id,
-                provider=provider.value,
-                provider_tenant_id=provider_tenant_id,
-                provider_uid=provider_uid,
-                access_token=access_token,
-                refresh_token=refresh_token,
-                token_expires_at=token_expires_at,
-                additional_data=serialized_additional_data,
+                provider=provider,
+                provider_tenant=provider_tenant,
+                provider_subject=provider_subject,
+                additional_data=additional_data,
                 is_deleted=False,
-                created_by="oauth",
-                updated_by="oauth",
+                created_by="identity_link",
+                updated_by="identity_link",
             )
-            .on_conflict_do_update(
-                index_elements=["user_id", "provider", "provider_uid"],
-                set_={
-                    "provider_tenant_id": provider_tenant_id,
-                    "token_expires_at": token_expires_at,
-                    "additional_data": serialized_additional_data,
-                    "updated_at": now,
-                    "updated_by": "oauth",
-                    "is_deleted": False,
-                },
-            )
+            .execute()
+        )
+
+    async def soft_delete_identity_link(self, user_id: UUID, provider: str) -> None:
+        await (
+            self._session.update(AuthIdentityLink)
+            .values(is_deleted=True, updated_at=datetime.now(timezone.utc), updated_by="identity_link")
+            .where(AuthIdentityLink.user_id == user_id)
+            .where(AuthIdentityLink.provider == provider)
+            .where(AuthIdentityLink.is_deleted == False)
             .execute()
         )

--- a/portal/libs/contexts/user_context.py
+++ b/portal/libs/contexts/user_context.py
@@ -16,7 +16,6 @@ class UserContext(BaseModel):
     """Per-request user information"""
 
     user_id: Optional[UUID] = None
-    phone_number: Optional[str] = None
     email: Optional[str] = None
     verified: bool = False
     is_active: bool = False

--- a/portal/middlewares/auth_middleware.py
+++ b/portal/middlewares/auth_middleware.py
@@ -195,7 +195,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         user_context = UserContext(
             user_id=user.id,
-            phone_number=user.phone_number,
             email=user.email,
             verified=user.verified,
             is_active=user.is_active,
@@ -244,7 +243,6 @@ class AuthMiddleware(BaseHTTPMiddleware):
 
         user_context = UserContext(
             user_id=user.id,
-            phone_number=user.phone_number,
             email=user.email,
             verified=user.verified,
             is_active=user.is_active,

--- a/portal/models/__init__.py
+++ b/portal/models/__init__.py
@@ -6,6 +6,8 @@ from .app import AppUser, AppUserPreferences
 from .audit import AuditLog
 from .auth import (
     AuthDevice,
+    AuthIdentityLink,
+    AuthIdentityProvider,
     AuthPermission,
     AuthPermissionTranslation,
     AuthRefreshToken,
@@ -17,7 +19,6 @@ from .auth import (
     AuthUser,
     AuthUserProfile,
     AuthUserRole,
-    AuthUserThirdParty,
     AuthVerb,
     AuthVerbTranslation,
 )
@@ -32,7 +33,8 @@ __all__ = [
     # user
     "AuthUser",
     "AuthUserProfile",
-    "AuthUserThirdParty",
+    "AuthIdentityProvider",
+    "AuthIdentityLink",
     # app end user (product FKs target AppUser.id, not AuthUser.id)
     "AppUser",
     "AppUserPreferences",

--- a/portal/models/auth/__init__.py
+++ b/portal/models/auth/__init__.py
@@ -4,13 +4,14 @@ Top-level package for auth models.
 
 from .rbac import AuthPermission, AuthPermissionTranslation, AuthResource, AuthResourceTranslation, AuthRole, AuthRoleTranslation, AuthVerb, AuthVerbTranslation
 from .relationships import AuthRolePermission, AuthUserRole
-from .user import AuthDevice, AuthRefreshToken, AuthUser, AuthUserProfile, AuthUserThirdParty
+from .user import AuthDevice, AuthIdentityLink, AuthIdentityProvider, AuthRefreshToken, AuthUser, AuthUserProfile
 
 __all__ = [
     # user
     "AuthUser",
     "AuthUserProfile",
-    "AuthUserThirdParty",
+    "AuthIdentityProvider",
+    "AuthIdentityLink",
     # rbac
     "AuthRole",
     "AuthRoleTranslation",

--- a/portal/models/auth/user.py
+++ b/portal/models/auth/user.py
@@ -1,5 +1,5 @@
 """
-User-related models: account, profile, third-party provider and auth.
+User-related models: Auth credential, profile, Identity provider / link, devices, tokens.
 """
 
 import sqlalchemy as sa
@@ -8,18 +8,17 @@ from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import relationship
 
 from portal.libs.consts.enums import Gender
-from portal.libs.database.orm import ModelBase
+from portal.libs.database.orm import Base, ModelBase
 from portal.models.mixins import AuditMixin, DeletedMixin, DescriptionMixin, RemarkMixin
 
 from .relationships import AuthUserRole
 
 
 class AuthUser(ModelBase, RemarkMixin, DeletedMixin, AuditMixin):
-    """Auth User Model"""
+    """Auth credential (sign-in subject)."""
 
-    email = Column(sa.String(255), nullable=True, unique=True, comment="Email, unique identifier")
-    phone_number = Column(sa.String(16), nullable=True, unique=True, comment="Phone number, unique identifier")
-    password_hash = Column(sa.String(512), nullable=True, comment="Password hash")
+    email = Column(sa.String(255), nullable=False, unique=True, comment="Email, required unique identifier")
+    password_hash = Column(sa.String(512), nullable=True, comment="Password hash; null for passwordless End users")
     salt = Column(sa.String(128), nullable=True, comment="Salt for password hash")
     verified = Column(sa.Boolean, default=False, comment="Is verified")
     is_active = Column(sa.Boolean, default=True, index=True, comment="Is active")
@@ -35,7 +34,7 @@ class AuthUser(ModelBase, RemarkMixin, DeletedMixin, AuditMixin):
 
 
 class AuthUserProfile(ModelBase, AuditMixin, DescriptionMixin):
-    """Auth User Profile Model"""
+    """Auth User Profile Model (admin-oriented)."""
 
     user_id = Column(UUID, sa.ForeignKey(AuthUser.id, ondelete="CASCADE"), nullable=False, unique=True, comment="User ID", index=True)
     first_name = Column(sa.String(64), nullable=False, comment="First name")
@@ -46,18 +45,38 @@ class AuthUserProfile(ModelBase, AuditMixin, DescriptionMixin):
     preferred_locale_id = Column(UUID, sa.ForeignKey("public.system_locale.id", ondelete="SET NULL"), nullable=True, index=True, comment="Preferred locale ID")
 
 
-class AuthUserThirdParty(ModelBase, DeletedMixin, AuditMixin):
-    """Auth User Third Party Model"""
+class AuthIdentityProvider(Base):
+    """Catalog of external sign-in sources (Identity provider)."""
 
-    __extra_table_args__ = (sa.UniqueConstraint("user_id", "provider", "provider_uid"),)
-    user_id = Column(UUID, sa.ForeignKey(AuthUser.id, ondelete="CASCADE", name="fk_user_third_party_user"), nullable=False, comment="User ID", index=True)
-    provider = Column(sa.String(16), nullable=False, comment="Provider name, Enum: ThirdPartyProvider")
-    provider_tenant_id = Column(UUID, nullable=False, comment="Provider tenant ID")
-    provider_uid = Column(sa.String(255), nullable=False, comment="Provider UID")
-    access_token = Column(sa.String(255), comment="Access token")
-    refresh_token = Column(sa.String(255), comment="Refresh token")
-    token_expires_at = Column(sa.TIMESTAMP(timezone=True), comment="Token expiration time")
-    additional_data = Column(JSONB, comment="Additional data")
+    code = Column(sa.String(32), primary_key=True, comment="Stable provider code, e.g. google, apple")
+    name = Column(sa.String(64), nullable=False, comment="English display name")
+    is_active = Column(sa.Boolean, nullable=False, server_default=sa.text("true"), comment="Whether provider may be used for new links")
+    requires_tenant = Column(sa.Boolean, nullable=False, server_default=sa.text("false"), comment="Whether provider_tenant is required on Identity links")
+
+
+class AuthIdentityLink(ModelBase, DeletedMixin, AuditMixin):
+    """Durable binding from an Identity provider subject to an Auth credential."""
+
+    __extra_table_args__ = (
+        sa.Index(
+            "uq_identity_link_provider_subject_active",
+            "provider",
+            "provider_tenant",
+            "provider_subject",
+            unique=True,
+            postgresql_where=sa.text("is_deleted IS false"),
+            postgresql_nulls_not_distinct=True,
+        ),
+        sa.Index("uq_identity_link_user_provider_active", "user_id", "provider", unique=True, postgresql_where=sa.text("is_deleted IS false")),
+    )
+
+    user_id = Column(UUID, sa.ForeignKey(AuthUser.id, ondelete="CASCADE"), nullable=False, index=True, comment="Auth credential ID")
+    provider = Column(
+        sa.String(32), sa.ForeignKey("auth.identity_provider.code", ondelete="RESTRICT"), nullable=False, index=True, comment="Identity provider code"
+    )
+    provider_tenant = Column(sa.String(255), nullable=True, comment="Optional provider tenant (string); null for consumer IdPs")
+    provider_subject = Column(sa.String(255), nullable=False, comment="Provider subject / stable user id at the IdP")
+    additional_data = Column(JSONB, comment="Optional IdP snapshot (email, name, auth_time); not the identity key")
 
 
 class AuthDevice(ModelBase, AuditMixin, DeletedMixin):

--- a/portal/schemas/auth.py
+++ b/portal/schemas/auth.py
@@ -1,13 +1,13 @@
 """
 Auth schemas
 """
+
 from pydantic import BaseModel
 
 
 class TokenPayload(BaseModel):
     """Token payload"""
+
     uid: str | None = None
     email: str | None = None
-    phone_number: str | None = None
     verified: bool = False
-

--- a/portal/serializers/admin/v1/user.py
+++ b/portal/serializers/admin/v1/user.py
@@ -26,7 +26,6 @@ class AdminUserQuery(GenericQueryBaseModel):
 class AdminUserBase(UUIDBaseModel, JSONStringMixinModel):
     """UserBase"""
 
-    phone_number: Optional[str] = Field(None, description="User's phone number", serialization_alias="phoneNumber")
     email: Optional[str] = Field(None, description="User's email address")
     display_name: Optional[str] = Field(None, description="User's display name", serialization_alias="displayName")
 
@@ -58,7 +57,6 @@ class AdminUserList(BaseModel):
 class AdminUserCreate(BaseModel):
     """UserCreate"""
 
-    phone_number: Optional[str] = Field(..., description="User's phone number")
     email: str = Field(..., description="User's email address")
     verified: bool = Field(False, description="Is the user verified")
     is_active: bool = Field(True, description="Is the user active")

--- a/tests/application/auth/test_create_credential_passwordless.py
+++ b/tests/application/auth/test_create_credential_passwordless.py
@@ -1,0 +1,56 @@
+"""Port seam: create_credential accepts null password_hash for passwordless End users."""
+
+from typing import Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.application.auth.results import UserSensitive
+
+
+class StubCredentialRepository:
+    def __init__(self) -> None:
+        self.created: list[dict] = []
+
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: Optional[str], is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
+        self.created.append(
+            {
+                "auth_user_id": auth_user_id,
+                "email": email,
+                "password_hash": password_hash,
+                "is_admin": is_admin,
+                "is_superuser": is_superuser,
+                "verified": verified,
+            }
+        )
+        return auth_user_id
+
+
+@pytest.mark.asyncio
+async def test_create_credential_allows_null_password_hash() -> None:
+    repo = StubCredentialRepository()
+    auth_user_id = uuid4()
+
+    result = await repo.create_credential(auth_user_id=auth_user_id, email="member@example.com", password_hash=None, is_admin=False, verified=True)
+
+    assert result == auth_user_id
+    assert repo.created[0]["password_hash"] is None
+    assert repo.created[0]["email"] == "member@example.com"
+
+
+@pytest.mark.asyncio
+async def test_create_credential_still_accepts_admin_password_hash() -> None:
+    repo = StubCredentialRepository()
+    auth_user_id = uuid4()
+
+    await repo.create_credential(
+        auth_user_id=auth_user_id, email="admin@example.com", password_hash="hashed:Secure1!", is_admin=True, is_superuser=True, verified=True
+    )
+
+    assert repo.created[0]["password_hash"] == "hashed:Secure1!"
+    assert repo.created[0]["is_admin"] is True
+    # Sensitive read model still allows optional password_hash
+    user = UserSensitive(id=auth_user_id, email="admin@example.com", password_hash="hashed:Secure1!", first_name="", last_name="")
+    assert user.password_hash == "hashed:Secure1!"

--- a/tests/application/auth/test_identity_link_port.py
+++ b/tests/application/auth/test_identity_link_port.py
@@ -1,0 +1,103 @@
+"""
+Port seam: UserRepositoryPort Identity-link lookup / upsert / soft-delete re-link.
+
+Uses an in-memory fake that encodes ADR 0005 active-row uniqueness so
+application code can depend on the contract before SQL is migrated.
+"""
+
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+
+class InMemoryIdentityLinkStore:
+    """Fake UserRepositoryPort Identity-link methods (active-row uniqueness)."""
+
+    def __init__(self) -> None:
+        self._links: list[dict[str, Any]] = []
+
+    def _active(self) -> list[dict[str, Any]]:
+        return [row for row in self._links if not row["is_deleted"]]
+
+    def _matches_subject(self, row: dict[str, Any], provider: str, provider_subject: str, provider_tenant: Optional[str]) -> bool:
+        return row["provider"] == provider and row["provider_subject"] == provider_subject and row["provider_tenant"] == provider_tenant
+
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
+        for row in self._active():
+            if self._matches_subject(row, provider, provider_subject, provider_tenant):
+                return row["user_id"]
+        return None
+
+    async def upsert_identity_link(
+        self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
+    ) -> None:
+        for row in self._active():
+            if self._matches_subject(row, provider, provider_subject, provider_tenant):
+                row["user_id"] = user_id
+                row["additional_data"] = additional_data
+                return
+            if row["user_id"] == user_id and row["provider"] == provider:
+                row["provider_subject"] = provider_subject
+                row["provider_tenant"] = provider_tenant
+                row["additional_data"] = additional_data
+                return
+        self._links.append(
+            {
+                "id": uuid4(),
+                "user_id": user_id,
+                "provider": provider,
+                "provider_tenant": provider_tenant,
+                "provider_subject": provider_subject,
+                "additional_data": additional_data,
+                "is_deleted": False,
+            }
+        )
+
+    async def soft_delete_identity_link(self, user_id: UUID, provider: str) -> None:
+        for row in self._active():
+            if row["user_id"] == user_id and row["provider"] == provider:
+                row["is_deleted"] = True
+                return
+
+
+@pytest.mark.asyncio
+async def test_identity_link_lookup_returns_user_after_upsert() -> None:
+    store = InMemoryIdentityLinkStore()
+    user_id = uuid4()
+
+    await store.upsert_identity_link(user_id, "google", "google-sub-1", additional_data={"email": "a@example.com"})
+
+    found = await store.get_user_id_by_identity_link("google", "google-sub-1")
+    assert found == user_id
+    assert await store.get_user_id_by_identity_link("google", "missing") is None
+    assert await store.get_user_id_by_identity_link("google", "google-sub-1", provider_tenant="tenant-a") is None
+
+
+@pytest.mark.asyncio
+async def test_identity_link_upsert_updates_additional_data_for_same_subject() -> None:
+    store = InMemoryIdentityLinkStore()
+    user_id = uuid4()
+
+    await store.upsert_identity_link(user_id, "apple", "apple-sub-1", additional_data={"v": 1})
+    await store.upsert_identity_link(user_id, "apple", "apple-sub-1", additional_data={"v": 2})
+
+    assert await store.get_user_id_by_identity_link("apple", "apple-sub-1") == user_id
+    active = [row for row in store._links if not row["is_deleted"]]
+    assert len(active) == 1
+    assert active[0]["additional_data"] == {"v": 2}
+
+
+@pytest.mark.asyncio
+async def test_identity_link_soft_delete_then_re_link_same_subject() -> None:
+    store = InMemoryIdentityLinkStore()
+    user_id = uuid4()
+
+    await store.upsert_identity_link(user_id, "google", "google-sub-1")
+    await store.soft_delete_identity_link(user_id, "google")
+    assert await store.get_user_id_by_identity_link("google", "google-sub-1") is None
+
+    await store.upsert_identity_link(user_id, "google", "google-sub-1", additional_data={"re": True})
+    assert await store.get_user_id_by_identity_link("google", "google-sub-1") == user_id
+    assert sum(1 for row in store._links if not row["is_deleted"]) == 1
+    assert sum(1 for row in store._links if row["is_deleted"]) == 1

--- a/tests/application/auth/test_identity_link_port.py
+++ b/tests/application/auth/test_identity_link_port.py
@@ -34,9 +34,12 @@ class InMemoryIdentityLinkStore:
     ) -> None:
         for row in self._active():
             if self._matches_subject(row, provider, provider_subject, provider_tenant):
+                if row["user_id"] != user_id:
+                    await self.soft_delete_identity_link(user_id, provider)
                 row["user_id"] = user_id
                 row["additional_data"] = additional_data
                 return
+        for row in self._active():
             if row["user_id"] == user_id and row["provider"] == provider:
                 row["provider_subject"] = provider_subject
                 row["provider_tenant"] = provider_tenant
@@ -101,3 +104,19 @@ async def test_identity_link_soft_delete_then_re_link_same_subject() -> None:
     assert await store.get_user_id_by_identity_link("google", "google-sub-1") == user_id
     assert sum(1 for row in store._links if not row["is_deleted"]) == 1
     assert sum(1 for row in store._links if row["is_deleted"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_identity_link_reassign_subject_clears_target_users_other_link() -> None:
+    store = InMemoryIdentityLinkStore()
+    user_a = uuid4()
+    user_b = uuid4()
+
+    await store.upsert_identity_link(user_a, "google", "shared-sub")
+    await store.upsert_identity_link(user_b, "google", "b-old-sub")
+    await store.upsert_identity_link(user_b, "google", "shared-sub")
+
+    assert await store.get_user_id_by_identity_link("google", "shared-sub") == user_b
+    active_for_b = [row for row in store._active() if row["user_id"] == user_b and row["provider"] == "google"]
+    assert len(active_for_b) == 1
+    assert active_for_b[0]["provider_subject"] == "shared-sub"

--- a/tests/application/cli/test_identity_provider_seed_data.py
+++ b/tests/application/cli/test_identity_provider_seed_data.py
@@ -1,0 +1,13 @@
+"""Seed data contract: google + apple only (ADR 0005)."""
+
+from portal.cli.datas.identity_provider_seed_data import seed_identity_providers
+
+
+def test_identity_provider_seed_is_google_and_apple_only() -> None:
+    codes = [row["code"] for row in seed_identity_providers]
+    assert codes == ["google", "apple"]
+    assert "microsoft" not in codes
+    for row in seed_identity_providers:
+        assert row["is_active"] is True
+        assert row["requires_tenant"] is False
+        assert isinstance(row["name"], str) and row["name"]

--- a/tests/models/auth/test_auth_identity_schema.py
+++ b/tests/models/auth/test_auth_identity_schema.py
@@ -1,0 +1,39 @@
+"""ORM seam: Auth credential + Identity provider / Identity link (ADR 0005)."""
+
+from portal.models import AuthIdentityLink, AuthIdentityProvider, AuthUser
+
+
+def test_auth_user_requires_email_and_drops_phone_number() -> None:
+    assert AuthUser.__table__.schema == "auth"
+    assert AuthUser.__tablename__ == "user"
+    assert AuthUser.__table__.c.email.nullable is False
+    assert "phone_number" not in AuthUser.__table__.c
+    assert AuthUser.__table__.c.password_hash.nullable is True
+
+
+def test_identity_provider_uses_code_primary_key() -> None:
+    assert AuthIdentityProvider.__table__.schema == "auth"
+    assert AuthIdentityProvider.__tablename__ == "identity_provider"
+    assert list(AuthIdentityProvider.__table__.primary_key.columns.keys()) == ["code"]
+    assert "name" in AuthIdentityProvider.__table__.c
+    assert "is_active" in AuthIdentityProvider.__table__.c
+    assert "requires_tenant" in AuthIdentityProvider.__table__.c
+    assert "id" not in AuthIdentityProvider.__table__.c
+
+
+def test_identity_link_has_no_oauth_token_columns_and_soft_delete() -> None:
+    assert AuthIdentityLink.__table__.schema == "auth"
+    assert AuthIdentityLink.__tablename__ == "identity_link"
+    columns = AuthIdentityLink.__table__.c
+    assert "provider" in columns
+    assert "provider_tenant" in columns
+    assert columns.provider_tenant.nullable is True
+    assert "provider_subject" in columns
+    assert columns.provider_subject.nullable is False
+    assert "additional_data" in columns
+    assert "is_deleted" in columns
+    assert "access_token" not in columns
+    assert "refresh_token" not in columns
+    assert "token_expires_at" not in columns
+    assert "provider_uid" not in columns
+    assert "provider_tenant_id" not in columns


### PR DESCRIPTION
## Summary

Implements durable Identity provider / Identity link storage (ADR 0005) and aligns Auth credential policy for passwordless End users: required email, no phone, nullable password hash, while Admin create/login remains password-first (ADR 0003). Replaces NewLife `user_third_party` with catalog + link models, seeds `google`/`apple`, and documents a human Alembic checklist (no agent edits under `alembic/versions/`).

Closes #12

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- App auth wording updated to magic-link (passwordless); OAuth/OIDC HTTP flows remain out of scope.
- `UserRepositoryPort` Identity-link lookup/upsert/soft-delete replaces third-party methods; active uniqueness preserved on subject reassign.
- Seed via `uv run python -m portal.cli.main seed-identity-providers` after tables exist (see `docs/migrations/0005-identity-link-alembic-checklist.md`).

## Testing

- [x] `uv run pytest`
- [x] `uv run ruff format` / `uv run ruff check --fix` on touched Python files

## Checklist

- [x] PR targets **`main`** (or this repo's default branch)
- [ ] CI green before merge