### PR TITLE
feat(auth): admin Google ID-token sign-in (#20)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,8 @@ This document helps AI agents quickly understand the **Rooted Core API** codebas
 | **Framework**       | FastAPI (async)                                                                                            |
 | **Database**        | PostgreSQL + SQLAlchemy (asyncpg)                                                                          |
 | **Cache**           | Redis (sessions, rate limiting, auth blacklist when enabled)                                               |
-| **Auth (app)**      | JWT — passwordless magic link for End users (see ADR 0003); Identity link storage ADR 0005; **no** Microsoft Entra / OIDC in scope |
-| **Auth (admin)**    | JWT + RBAC — email/password for admin console at `/admin`                                                   |
+| **Auth (app)**      | JWT — passwordless magic link for End users (see ADR 0003); Identity link storage ADR 0005; End-user Apple/Google HTTP still future |
+| **Auth (admin)**    | JWT + RBAC — email/password and Google ID-token (ADR 0006); **no** Microsoft Entra / Admin Apple            |
 | **DI**              | `dependency-injector`                                                                                      |
 | **Package manager** | uv (`uv run …`)                                                                                            |
 | **Python**          | 3.14+ (see `pyproject.toml`)                                                                               |
@@ -146,7 +146,7 @@ Rooted v1 domains (from PRD and `rooted-docs`). Use these folder names when addi
 
 | Context    | Responsibility                                      |
 | ---------- | --------------------------------------------------- |
-| **auth**   | Magic-link (passwordless) End-user auth, Admin password login, refresh, JWT; Identity links (ADR 0005) |
+| **auth**   | Magic-link End-user auth; Admin password + Google (ADR 0006); refresh, JWT; Identity links (ADR 0005) |
 | **users**  | Profile, preferences, account deletion              |
 | **sync**   | Client ↔ server sync for v1                         |
 | **reports**| User reports + moderation queue                     |
@@ -208,14 +208,14 @@ See ADR 0003.
 
 - **Passwordless:** magic-link request/verify for End users (ADR 0003). Auth credentials may have `password_hash` null.
 - Shared JWT access/refresh infrastructure with Admin; product FKs hang off End user (`app.user`), not `auth.user` alone (ADR 0004).
-- Identity provider catalog + Identity link rows prepare Apple/Google storage (ADR 0005) — OAuth/OIDC HTTP flows are a future ADR.
-- **Excluded:** Microsoft Entra ID token exchange, app password register/login as the product path, phone-as-login-id.
+- Identity provider catalog + Identity link rows (ADR 0005). **Admin Google** ID-token HTTP is ADR 0006. End-user Apple/Google HTTP remains a future ADR.
+- **Excluded:** Microsoft Entra ID token exchange, Admin Apple, app password register/login as the product path, phone-as-login-id.
 
 ### Admin
 
 1. `AuthMiddleware` validates Bearer JWT and loads admin user.
 2. RBAC via permissions on admin routes (see `portal.libs.consts.permission` pattern).
-3. Admin create/login remains **email + password** on the shared Auth credential.
+3. Admin create/login: **email + password** and/or **Google** on the shared Auth credential (ADR 0006).
 
 ### Auth levels (product)
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -121,20 +121,20 @@ End-user settings and presentation defaults (display name, locale, theme, font s
 _Avoid_: Admin User profile fields, burying prefs inside fellowship or journal rows
 
 **Admin User**:
-Staff account using the **admin** API (`/admin`) for RBAC, content, and moderation — distinct from **shepherd** (group role) and from **End user**. May share the same auth credential as an End user when one person holds both capacities.
-_Avoid_: Operator, treating Membership role as admin
+Staff account using the **admin** API (`/admin`) for RBAC, content, and moderation — distinct from **shepherd** (group role) and from **End user**. May share the same auth credential as an End user when one person holds both capacities. Signs in with that **Auth credential** via password and/or an **Identity link**; an Identity-provider sign-in alone never creates an Admin User.
+_Avoid_: Operator, treating Membership role as admin, auto-provisioning staff from Google/Apple alone
 
 **Auth credential**:
 The sign-in subject in `auth.user`, always identified by a required email, with optional password and zero or more **Identity links**. An **End user** and an **Admin User** may share one credential; product data hangs off **End user**, not off this row. Phone number is not part of this credential.
 _Avoid_: Account (ambiguous), conflating with **End user** / `app.user`, phone-as-login-id
 
 **Identity provider**:
-A known external sign-in source (e.g. Google, Apple, Microsoft) registered in the auth catalog — not the person’s account at that vendor, and not an OAuth token.
-_Avoid_: Social network, OAuth client, treating a free-form string as the provider without a catalog entry
+A known external sign-in source (e.g. Google, Apple) registered in the auth catalog — not the person’s account at that vendor, and not an OAuth token. **Google** may be used for **Admin User** and (later) **End user** sign-in. **Apple** is only for **End user** sign-in — never for the admin console. Microsoft is not a Rooted Identity provider.
+_Avoid_: Social network, OAuth client, treating a free-form string as the provider without a catalog entry, Microsoft Entra as an in-scope provider, Apple sign-in for Admin Users
 
 **Identity link**:
-A durable binding from an **Identity provider** subject (and optional provider tenant) to one **Auth credential**. One credential may have many links across providers; at most one active link per credential per provider; each provider subject binds to at most one credential. Used to recognize the same person on later sign-ins — not an OAuth token store and not a product profile.
-_Avoid_: OAuth session, social account, third-party login (as the noun for the row), storing provider access/refresh tokens as the purpose of this concept
+A durable binding from an **Identity provider** subject (and optional provider tenant) to one **Auth credential**. One credential may have many links across providers; at most one active link per credential per provider; each provider subject binds to at most one credential. Used to recognize the same person on later sign-ins — not an OAuth token store and not a product profile. For **Google**, the provider subject is the account’s stable IdP user id (same across Rooted’s different OAuth clients such as admin console vs future app); Rooted does **not** create one Google Identity link per client application. For **End user** sign-in (future), a first successful Identity-provider sign-in may create the Auth credential and End user; for **Admin User** sign-in it only binds to an already-admin credential, and only via **Google** in the admin console. A first Admin Google success that matches by verified email creates the link; later sign-ins resolve primarily by provider subject.
+_Avoid_: OAuth session, social account, third-party login (as the noun for the row), storing provider access/refresh tokens as the purpose of this concept, matching Admin sign-in by email alone after a link exists, Admin Apple Identity links as a product path, one Google Identity link per OAuth client id
 
 **Report**:
 User flag on fellowship content (prayer, share, etc.) with reason code — feeds moderation queue in v1.
@@ -162,4 +162,4 @@ Client ↔ server reconciliation for v1 accounts — not a second product surfac
 | PRD | `rooted-docs/docs/product/prd.md` |
 | API spec | `rooted-docs/docs/backend/api-specification.md` |
 | Database design | `rooted-docs/docs/backend/database-design.md` |
-| ADRs | `docs/adr/` (auth identity storage: ADR 0005) |
+| ADRs | `docs/adr/` (identity storage: ADR 0005; Admin Google: ADR 0006) |

--- a/docs/adr/0003-auth-strategy-newlife-password-first.md
+++ b/docs/adr/0003-auth-strategy-newlife-password-first.md
@@ -1,31 +1,32 @@
-# ADR 0003 — Auth strategy: Admin password-first; app End users passwordless (magic link)
+# ADR 0003 — Auth strategy: Admin password + Google; app End users passwordless (magic link)
 
 ## Status
 
-Accepted (Phase 0, 2026-08-27); **updated** (2026-09-05) for app passwordless.
+Accepted (Phase 0, 2026-08-27); **updated** (2026-09-05) for app passwordless; **updated** (2026-09-05) for Admin Google via ADR 0006.
 
-Supersedes the earlier “app password + optional magic link” wording in this ADR. Durable Identity storage for future Apple/Google is ADR 0005 — this ADR does **not** authorize OIDC HTTP flows.
+Supersedes the earlier “app password + optional magic link” wording in this ADR. Durable Identity storage is ADR 0005. **Admin Google ID-token HTTP flow** is authorized by **ADR 0006** (not by this ADR alone). End-user Apple/Google HTTP flows still need a future ADR. Microsoft Entra remains out of scope.
 
 ## Context
 
 Rooted requires account-backed sync and fellowship (`rooted-docs` PRD §9.4, API spec §2). The codebase inherits JWT, password hashing, and admin RBAC patterns from the portal/NewLife lineage.
 
-Product direction for **End users** is **passwordless**: magic-link email login now; Apple/Google Identity links later (schema in ADR 0005). **Admin Users** still need email + password on the shared **Auth credential** table. NewLife’s Microsoft Entra ID token exchange serves church staff SSO — not Rooted’s consumer audience — and remains out of scope.
+Product direction for **End users** is **passwordless**: magic-link email login now; Apple/Google Identity links later (schema in ADR 0005; HTTP in a future ADR). **Admin Users** sign in on the shared **Auth credential** with **email + password** and, per ADR 0006, optional **Google** ID-token exchange on the admin console. NewLife’s Microsoft Entra ID token exchange serves church staff SSO — not Rooted’s audience — and remains out of scope.
 
 ## Decision
 
 1. **Shared infrastructure:** JWT access + refresh tokens, password hashing providers, and refresh rotation/blacklist as enabled — same plumbing for Admin and (when issued) member tokens.
-2. **Admin Users** authenticate via `/admin/api/v1/auth` with **email + password** and RBAC. No Microsoft/OIDC login for Rooted admin.
-3. **App End users** authenticate via **magic link only** (request + verify). Do **not** expose app password register/login as the product path. Magic-link verify may create an Auth credential with `password_hash` null plus End user + Preferences.
-4. **Auth credential:** required email; optional password (required for Admin create/login); zero or more Identity links (ADR 0005). Phone is not a credential identifier.
-5. **Explicitly out of scope:** Microsoft Entra / Azure AD token exchange, generic OIDC social login, and NewLife-style `MicrosoftAuthService`. Enabling Apple/Google HTTP flows requires a future ADR on top of ADR 0005 storage.
+2. **Admin Users** authenticate via `/admin/api/v1/auth` with **email + password** and/or **Google** (ADR 0006), then RBAC. **No** Microsoft/Entra login. **No** Apple on the admin console.
+3. **App End users** authenticate via **magic link only** (request + verify) until a future ADR adds Apple/Google. Do **not** expose app password register/login as the product path. Magic-link verify may create an Auth credential with `password_hash` null plus End user + Preferences.
+4. **Auth credential:** required email; optional password (required for Admin password create/login; Google-linked admins may still keep a password). Zero or more Identity links (ADR 0005). Phone is not a credential identifier.
+5. **Explicitly out of scope here:** Microsoft Entra / Azure AD token exchange, NewLife-style `MicrosoftAuthService`, Admin Apple, and End-user Apple/Google HTTP (future ADR). Generic “port all NewLife OIDC” is not authorized.
 6. **Token policy:** follow product ranges (access ~15–60 minutes, refresh ~7–30 days) via configuration; clients send `Authorization: Bearer`.
 7. **Anonymous access:** allow unauthenticated reads where the API spec marks devotion/bible as client-first; fellowship and journal require member JWT.
 
 ## Consequences
 
-- No OIDC client secrets or Entra app registration in Rooted deployments.
+- Admin Google needs Google Client ID allowlist configuration (ADR 0006); Microsoft/Entra app registration stays out.
 - Agents must not reintroduce app password register/login as the primary End-user path.
 - Admin password create/login must keep working on the same `auth.user` rows End users use (shared credential; ADR 0004).
 - Magic-link token storage is ephemeral (e.g. Redis TTL), not on Identity link rows.
-- If enterprise SSO is ever required, it demands a new ADR — it is not a silent port from `newlife-core-api`.
+- Enterprise Microsoft SSO, if ever required, demands a new ADR — it is not a silent port from `newlife-core-api`.
+- See ADR 0006 for Admin Google link/provisioning rules and portal contract-test implications.

--- a/docs/adr/0005-identity-link-and-provider-catalog.md
+++ b/docs/adr/0005-identity-link-and-provider-catalog.md
@@ -4,7 +4,7 @@
 
 Accepted (2026-09-04)
 
-Supersedes ADR 0004’s retention of NewLife-shaped `auth.user_third_party` as the forward model. Does **not** supersede ADR 0003: enabling Apple/Google (or any IdP) sign-in still needs its own product/implementation ADR; this decision only reshapes durable identity storage.
+Supersedes ADR 0004’s retention of NewLife-shaped `auth.user_third_party` as the forward model. Does **not** supersede ADR 0003. This decision only reshapes durable identity storage. **Admin Google** HTTP is ADR 0006; **End-user** Apple/Google HTTP still need a future ADR.
 
 ## Context
 
@@ -26,7 +26,7 @@ We need a table design that can hold most third-party sign-in bindings before th
 
 4. **Auth credential shape**: `email` is **NOT NULL**; drop `phone_number`. No email-less `auth.user` rows. Account-merge when the same email arrives via a new IdP is **out of scope** (no pending-merge table); decide in a future sign-in ADR.
 
-5. **Out of scope here**: OAuth/OIDC HTTP flows, token exchange, auto-link-by-email product rules, and Microsoft / church SSO (still ADR 0003 + a future ADR if needed).
+5. **Out of scope here**: OAuth/OIDC HTTP flows, token exchange, auto-link-by-email product rules, and Microsoft / church SSO. Admin Google HTTP + auto-link-by-email for admin is **ADR 0006**; End-user IdP HTTP remains a future ADR.
 
 ## Considered options
 
@@ -44,5 +44,5 @@ We need a table design that can hold most third-party sign-in bindings before th
 - ORM and human-owned Alembic should introduce `identity_provider` / `identity_link` and adjust `auth.user` (`email` NOT NULL, drop `phone_number`); remove or stop using `user_third_party` and token columns.
 - Repository ports that upsert by `provider_uid` / UUID tenant must move to `provider_subject` + nullable `provider_tenant`.
 - `ThirdPartyProvider` / Microsoft leftovers stay dead until a sign-in ADR; catalog codes are the source of truth for allowed providers.
-- Implementing Apple or Google login is still a separate ADR and must not be inferred from this schema alone.
+- Implementing sign-in HTTP must not be inferred from this schema alone: Admin Google → ADR 0006; End-user Apple/Google → future ADR.
 - Human Alembic steps: see `docs/migrations/0005-identity-link-alembic-checklist.md`.

--- a/docs/adr/0006-admin-google-id-token-sign-in.md
+++ b/docs/adr/0006-admin-google-id-token-sign-in.md
@@ -1,0 +1,50 @@
+# ADR 0006 — Admin Google ID-token sign-in (Identity link HTTP flow)
+
+## Status
+
+Accepted (2026-09-05)
+
+Authorizes the first Identity-provider HTTP flow on top of ADR 0005 storage. Amends ADR 0003’s “admin password only / no OIDC” clause for **Google on the admin console only**. Does **not** authorize End-user Google/Apple app flows (future ADR) or Microsoft Entra.
+
+## Context
+
+ADR 0005 delivered `identity_provider` / `identity_link` and seeded `google` + `apple`, but left OAuth/OIDC HTTP flows to a later decision. Product still schedules End-user Apple/Google for a later app phase; staff asked to enable **Google sign-in on the Rooted admin portal** first, while keeping password login and without public Admin self-registration.
+
+Google issues a stable account `sub` across OAuth clients (Web / iOS / Android). Rooted’s link uniqueness is `(provider, provider_tenant, provider_subject)` — one Google subject maps to one Auth credential, not one link per Client ID. Client IDs still matter for ID-token `aud` verification.
+
+## Decision
+
+1. **Surface (this slice):** Admin console + `/admin/api/v1/auth` only. End-user `/api/v1` Google/Apple remain unauthorized here.
+
+2. **Protocol:** Portal uses Google Identity Services (or equivalent) to obtain a Google **ID token** and posts it to the admin API. The API verifies signature/`iss`/`exp`, requires `email_verified`, and accepts `aud` against a configured **Client ID allowlist** (start with the portal Web client; add app clients later without changing link cardinality).
+
+3. **Enablement (two layers):** Google sign-in is offered only when **both** are true: `auth.identity_provider` row `google` has `is_active`, **and** at least one Google Client ID is configured in deployment env/secrets. Catalog flags are not a substitute for Client IDs (ADR 0005 stores no OAuth client material). Portal may gate GIS on `VITE_GOOGLE_CLIENT_ID`; the API still enforces `is_active` and verification config.
+
+4. **Provisioning:** Never create an Admin User from Google alone. Resolve in order: existing Identity link by `(google, sub)` → else match verified email (case-insensitive) to an Auth credential that is already admin-eligible (`is_admin`, verified, active) and **upsert** the Identity link. Password login remains available; linking Google does not clear `password_hash`. Unlink is out of scope for this slice.
+
+5. **Errors:** Fail with a **generic** sign-in failure toward clients (no account-enumeration detail for missing email, non-admin, inactive, etc.).
+
+6. **Apple:** Catalog entry remains for **End-user** app sign-in later. **Do not** expose Apple on the admin console. Admin Identity-provider sign-in is Google-only.
+
+7. **Microsoft / Entra:** Still out of scope (unchanged from ADR 0003 intent).
+
+8. **Future End users (non-binding sketch for the next ADR):** First Google/Apple success may create Auth credential + End user; same Google `sub` reuses one Identity link if the person later becomes an Admin on that credential. Detail and magic-link interaction belong in that future ADR.
+
+## Considered options
+
+| Topic | Rejected | Why |
+| ----- | -------- | --- |
+| Authorization-code exchange for admin SPA | Extra server round-trip | ID token verify matches portal needs; no Google API scopes required |
+| One Identity link per OAuth Client ID | Pairwise / per-app rows | Conflicts with ADR 0005 uniqueness; Google `sub` is account-stable |
+| Auto-create Admin from Google | Faster staff onboarding | Admin remains invite/provisioned; no public staff signup |
+| Admin Apple parity with Google | Symmetric IdPs | Product: Apple is app/store-oriented; admin console is Google + password only |
+| Feature flag separate from `is_active` + Client ID | Third switch | Two layers already cover product off and missing secrets |
+| Hosted-domain (`hd`) allowlist now | Extra org assumption | Existing-admin email match is enough for v1 admin Google |
+
+## Consequences
+
+- Implement admin Google verify + login path; reuse existing admin JWT completion after credential resolution.
+- Revise ADR 0003 decision text so admin auth is **password and/or Google**, not password-only.
+- `rooted-portal-frontend` must relax password-only acceptance tests to allow Google while still forbidding Microsoft/MSAL/Entra.
+- Ops: configure Google Web Client ID (allowlist) and keep `identity_provider.google.is_active` under operational control.
+- Agents must not infer End-user Google/Apple HTTP from this ADR alone; must not add Admin Apple or Microsoft from NewLife by analogy.

--- a/example.env
+++ b/example.env
@@ -34,6 +34,9 @@ REFRESH_TOKEN_HASH_PEPPER=
 # App magic link
 MAGIC_LINK_TOKEN_EXPIRE_MINUTES=15
 
+# Admin Google ID-token sign-in (ADR 0006) — comma-separated Client ID allowlist; empty disables Google admin sign-in
+GOOGLE_ADMIN_CLIENT_IDS=
+
 # Logging
 SENSITIVE_PARAMS=password,token,secret
 

--- a/portal/application/auth/admin_google_auth_service.py
+++ b/portal/application/auth/admin_google_auth_service.py
@@ -4,7 +4,7 @@ Admin Google ID-token sign-in application service (ADR 0006).
 
 from portal.application.auth.commands import AdminGoogleLoginCommand
 from portal.application.auth.login_service import LoginService
-from portal.application.auth.results import LoginResult
+from portal.application.auth.results import LoginResult, UserSensitive
 from portal.config import settings
 from portal.domain.auth.ports import GoogleIdTokenVerifierPort, UserRepositoryPort
 from portal.exceptions.responses import UnauthorizedException
@@ -12,6 +12,10 @@ from portal.libs.tracing.distributed_trace import distributed_trace
 
 GOOGLE_PROVIDER_CODE = "google"
 GENERIC_FAILURE_DETAIL = "Google sign-in failed"
+
+
+def _is_admin_eligible(user: UserSensitive) -> bool:
+    return user.is_admin and user.verified and user.is_active
 
 
 class AdminGoogleAuthService:
@@ -40,12 +44,12 @@ class AdminGoogleAuthService:
         linked_user_id = await self._repository.get_user_id_by_identity_link(GOOGLE_PROVIDER_CODE, claims.subject)
         if linked_user_id:
             user = await self._repository.get_sensitive_by_id(linked_user_id)
-            if not user:
+            if not user or not _is_admin_eligible(user):
                 raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
             return await self._login_service.complete_admin_login(user)
 
         user = await self._repository.get_sensitive_by_email(claims.email)
-        if not user or not user.is_admin or not user.verified or not user.is_active:
+        if not user or not _is_admin_eligible(user):
             raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
 
         await self._repository.upsert_identity_link(user.id, GOOGLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})

--- a/portal/application/auth/admin_google_auth_service.py
+++ b/portal/application/auth/admin_google_auth_service.py
@@ -1,0 +1,52 @@
+"""
+Admin Google ID-token sign-in application service (ADR 0006).
+"""
+
+from portal.application.auth.commands import AdminGoogleLoginCommand
+from portal.application.auth.login_service import LoginService
+from portal.application.auth.results import LoginResult
+from portal.config import settings
+from portal.domain.auth.ports import GoogleIdTokenVerifierPort, UserRepositoryPort
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+GOOGLE_PROVIDER_CODE = "google"
+GENERIC_FAILURE_DETAIL = "Google sign-in failed"
+
+
+class AdminGoogleAuthService:
+    """Resolve a verified Google ID token to an existing admin-eligible Auth credential and issue admin tokens."""
+
+    def __init__(self, user_repository: UserRepositoryPort, google_id_token_verifier: GoogleIdTokenVerifierPort, login_service: LoginService):
+        self._repository = user_repository
+        self._verifier = google_id_token_verifier
+        self._login_service = login_service
+
+    @distributed_trace()
+    async def login_with_google(self, command: AdminGoogleLoginCommand) -> LoginResult:
+        """
+        Resolution order (ADR 0006): existing Identity link by `sub`, else verified email
+        (case-insensitive) match to an admin-eligible Auth credential, then upsert the link.
+        Every rejection path raises the same generic failure — no account enumeration.
+        """
+        client_ids = settings.google_admin_client_ids
+        if not client_ids or not await self._repository.identity_provider_is_active(GOOGLE_PROVIDER_CODE):
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        claims = await self._verifier.verify(command.id_token, audiences=client_ids)
+        if not claims or not claims.email_verified or not claims.email:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        linked_user_id = await self._repository.get_user_id_by_identity_link(GOOGLE_PROVIDER_CODE, claims.subject)
+        if linked_user_id:
+            user = await self._repository.get_sensitive_by_id(linked_user_id)
+            if not user:
+                raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+            return await self._login_service.complete_admin_login(user)
+
+        user = await self._repository.get_sensitive_by_email(claims.email)
+        if not user or not user.is_admin or not user.verified or not user.is_active:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        await self._repository.upsert_identity_link(user.id, GOOGLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})
+        return await self._login_service.complete_admin_login(user)

--- a/portal/application/auth/commands.py
+++ b/portal/application/auth/commands.py
@@ -45,6 +45,12 @@ class MicrosoftLoginCommand(BaseModel):
     id_token: str = Field(..., description="Microsoft ID token")
 
 
+class AdminGoogleLoginCommand(BaseModel):
+    """Admin Google ID-token sign-in command (ADR 0006)."""
+
+    id_token: str = Field(..., description="Google ID token from Google Identity Services")
+
+
 class LogoutCommand(BaseModel):
     """Logout command."""
 

--- a/portal/config.py
+++ b/portal/config.py
@@ -120,6 +120,9 @@ class Configuration(BaseSettings):
     # [App magic link]
     MAGIC_LINK_TOKEN_EXPIRE_MINUTES: int = int(os.getenv(key="MAGIC_LINK_TOKEN_EXPIRE_MINUTES", default="15"))
 
+    # [Admin Google ID-token sign-in — ADR 0006. Comma-separated Client ID allowlist; empty disables Google admin sign-in.]
+    GOOGLE_ADMIN_CLIENT_IDS: str = os.getenv(key="GOOGLE_ADMIN_CLIENT_IDS", default="")
+
     # [Member web apps — Origin -> app_code for /api/v1 auth]
     MEMBER_WEB_APPS: str = os.getenv(key="MEMBER_WEB_APPS", default="rooted-app|http://localhost:5174")
 
@@ -189,6 +192,10 @@ class Configuration(BaseSettings):
     @property
     def is_dev(self) -> bool:
         return self.ENV.lower() not in ("prod", "stg")
+
+    @property
+    def google_admin_client_ids(self) -> list[str]:
+        return [client_id.strip() for client_id in self.GOOGLE_ADMIN_CLIENT_IDS.split(",") if client_id.strip()]
 
 
 @lru_cache

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -36,6 +36,7 @@ class RootContainer(containers.DeclarativeContainer):
     user_read_service = admin.user_read_service
     admin_user_service = admin.admin_user_service
     login_service = admin.login_service
+    admin_google_auth_service = admin.admin_google_auth_service
     refresh_token_service = admin.refresh_token_service
     member_web_app_registry = admin.member_web_app_registry
     locale_service = admin.locale_service

--- a/portal/containers/admin.py
+++ b/portal/containers/admin.py
@@ -5,6 +5,7 @@ Admin bounded context application services.
 from dependency_injector import containers, providers
 
 from portal.application.audit.rbac_audit_service import RbacAuditService
+from portal.application.auth.admin_google_auth_service import AdminGoogleAuthService
 from portal.application.auth.admin_user_service import AdminUserService
 from portal.application.auth.login_service import LoginService
 from portal.application.auth.refresh_token_service import RefreshTokenService
@@ -83,6 +84,9 @@ class AdminContainer(containers.DeclarativeContainer):
         role_service=role_service,
         permission_service=permission_service,
         member_refresh_app_binding_provider=core.member_refresh_app_binding_provider,
+    )
+    admin_google_auth_service = providers.Factory(
+        AdminGoogleAuthService, user_repository=user_repository, google_id_token_verifier=core.google_id_token_verifier, login_service=login_service
     )
     refresh_token_service = providers.Factory(
         RefreshTokenService,

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -7,6 +7,7 @@ from dependency_injector import containers, providers
 from portal.config import settings
 from portal.libs.database import PostgresConnection, RedisPool, Session
 from portal.libs.database.session_proxy import SessionProxy
+from portal.providers.google_id_token_verifier import GoogleIdTokenVerifier
 from portal.providers.jwt_provider import JWTProvider
 from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
 from portal.providers.password_provider import PasswordProvider
@@ -31,3 +32,4 @@ class CoreContainer(containers.DeclarativeContainer):
     jwt_provider = providers.Singleton(JWTProvider, token_blacklist_provider=token_blacklist_provider)
     password_provider = providers.Singleton(PasswordProvider)
     refresh_token_provider = providers.Factory(RefreshTokenProvider, session=request_session)
+    google_id_token_verifier = providers.Singleton(GoogleIdTokenVerifier)

--- a/portal/domain/auth/entities.py
+++ b/portal/domain/auth/entities.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from portal.domain.common.mixins import UUIDModel
 from portal.libs.consts.enums import Gender
@@ -26,3 +26,12 @@ class User(UUIDModel):
     preferred_name: Optional[str] = Field(default=None, description="Preferred display name")
     preferred_locale_id: Optional[UUID] = Field(default=None, description="Preferred locale id")
     gender: Optional[Gender] = Field(default=None, description="Gender")
+
+
+class GoogleIdentityClaims(BaseModel):
+    """Verified Google ID token claims relevant to Admin sign-in resolution (ADR 0006)."""
+
+    subject: str = Field(..., description="Google account stable subject (sub); stable across Rooted's OAuth clients")
+    email: Optional[str] = Field(default=None, description="Email claim as asserted by Google")
+    email_verified: bool = Field(default=False, description="Whether Google verified the email claim")
+    audience: str = Field(..., description="Token audience (aud) — the Client ID the token was issued for")

--- a/portal/domain/auth/ports.py
+++ b/portal/domain/auth/ports.py
@@ -6,6 +6,7 @@ from typing import Any, Optional, Protocol
 from uuid import UUID
 
 from portal.application.auth.results import UserDetail, UserSensitive
+from portal.domain.auth.entities import GoogleIdentityClaims
 
 
 class UserRepositoryPort(Protocol):
@@ -32,6 +33,8 @@ class UserRepositoryPort(Protocol):
     ) -> None: ...
 
     async def soft_delete_identity_link(self, user_id: UUID, provider: str) -> None: ...
+
+    async def identity_provider_is_active(self, code: str) -> bool: ...
 
     async def create_directory_user(
         self,
@@ -72,3 +75,11 @@ class MagicLinkMailerPort(Protocol):
     """Deliver the plain magic-link token out-of-band (email)."""
 
     async def send_magic_link(self, email: str, token: str) -> None: ...
+
+
+class GoogleIdTokenVerifierPort(Protocol):
+    """Verify a Google-issued ID token (signature, issuer, expiry, audience) per ADR 0006."""
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[GoogleIdentityClaims]:
+        """Return verified claims, or None when the token is invalid, expired, or not issued for one of `audiences`."""
+        ...

--- a/portal/infrastructure/persistence/repositories/user_repository.py
+++ b/portal/infrastructure/persistence/repositories/user_repository.py
@@ -16,7 +16,7 @@ from portal.domain.auth.constants import AuthErrorCode
 from portal.exceptions.responses import ConflictErrorException
 from portal.libs.consts.enums import Gender
 from portal.libs.database import Session
-from portal.models import AuthIdentityLink, AuthUser, AuthUserProfile, AuthUserRole, SystemLocale
+from portal.models import AuthIdentityLink, AuthIdentityProvider, AuthUser, AuthUserProfile, AuthUserRole, SystemLocale
 
 
 class UserRepository:
@@ -478,6 +478,10 @@ class UserRepository:
             )
             .execute()
         )
+
+    async def identity_provider_is_active(self, code: str) -> bool:
+        is_active = await self._session.select(AuthIdentityProvider.is_active).where(AuthIdentityProvider.code == code).fetchval()
+        return bool(is_active)
 
     async def soft_delete_identity_link(self, user_id: UUID, provider: str) -> None:
         await (

--- a/portal/providers/google_id_token_verifier.py
+++ b/portal/providers/google_id_token_verifier.py
@@ -1,0 +1,35 @@
+"""
+Google ID token verifier (ADR 0006) — signature, issuer, expiry, and audience via PyJWT + Google's published JWKS.
+"""
+
+from typing import Optional
+
+import jwt
+
+from portal.domain.auth.entities import GoogleIdentityClaims
+from portal.libs.logger import logger
+
+GOOGLE_JWKS_URL = "https://www.googleapis.com/oauth2/v3/certs"
+GOOGLE_ISSUERS = {"https://accounts.google.com", "accounts.google.com"}
+
+
+class GoogleIdTokenVerifier:
+    """Verifies Google-issued ID tokens against Google's published JWKS (RS256)."""
+
+    def __init__(self):
+        self._jwk_client = jwt.PyJWKClient(GOOGLE_JWKS_URL)
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[GoogleIdentityClaims]:
+        if not id_token or not audiences:
+            return None
+        try:
+            signing_key = self._jwk_client.get_signing_key_from_jwt(id_token)
+            claims = jwt.decode(id_token, signing_key.key, algorithms=["RS256"], audience=audiences, issuer=GOOGLE_ISSUERS)
+        except jwt.PyJWTError as error:
+            logger.warning(f"Google ID token verification failed: {error}")
+            return None
+
+        subject = claims.get("sub")
+        if not subject:
+            return None
+        return GoogleIdentityClaims(subject=subject, email=claims.get("email"), email_verified=bool(claims.get("email_verified")), audience=claims.get("aud"))

--- a/portal/routers/admin/v1/auth.py
+++ b/portal/routers/admin/v1/auth.py
@@ -7,14 +7,15 @@ import uuid
 from dependency_injector.wiring import Provide, inject
 from fastapi import Cookie, Depends, Response, status
 
-from portal.application.auth.commands import LoginCommand, LoginWithoutValidateCommand, LogoutCommand, RefreshTokenCommand
+from portal.application.auth.admin_google_auth_service import AdminGoogleAuthService
+from portal.application.auth.commands import AdminGoogleLoginCommand, LoginCommand, LoginWithoutValidateCommand, LogoutCommand, RefreshTokenCommand
 from portal.application.auth.login_service import LoginService
 from portal.application.auth.mappers import admin_profile_result_to_api, login_result_to_api, token_result_to_api
 from portal.application.auth.refresh_token_service import RefreshTokenService
 from portal.config import settings
 from portal.container import Container
 from portal.routers.auth_router import AuthRouter
-from portal.serializers.admin.v1.auth import AdminInfo, AdminLoginRequest, AdminLoginResponse
+from portal.serializers.admin.v1.auth import AdminGoogleLoginRequest, AdminInfo, AdminLoginRequest, AdminLoginResponse
 from portal.serializers.mixins import LogoutRequest, LogoutResponse, RefreshTokenRequest, TokenResponse
 
 router: AuthRouter = AuthRouter(is_admin=True)
@@ -48,6 +49,15 @@ if settings.is_dev:
 @inject
 async def admin_login(body: AdminLoginRequest, login_service: LoginService = Depends(Provide[Container.login_service])):
     result = await login_service.login_with_password(LoginCommand(email=body.email, password=body.password))
+    return login_result_to_api(result)
+
+
+@router.post("/google", response_model=AdminLoginResponse, response_model_by_alias=True, require_auth=False)
+@inject
+async def admin_google_login(
+    body: AdminGoogleLoginRequest, admin_google_auth_service: AdminGoogleAuthService = Depends(Provide[Container.admin_google_auth_service])
+):
+    result = await admin_google_auth_service.login_with_google(AdminGoogleLoginCommand(id_token=body.id_token))
     return login_result_to_api(result)
 
 

--- a/portal/serializers/admin/v1/auth.py
+++ b/portal/serializers/admin/v1/auth.py
@@ -55,3 +55,9 @@ class MicrosoftIdTokenRequest(BaseModel):
     """Microsoft Entra ID token exchange body"""
 
     id_token: str = Field(..., description="Microsoft ID token")
+
+
+class AdminGoogleLoginRequest(BaseModel):
+    """Admin Google ID-token sign-in request body (ADR 0006)"""
+
+    id_token: str = Field(..., description="Google ID token from Google Identity Services")

--- a/tests/application/auth/test_admin_google_auth_service.py
+++ b/tests/application/auth/test_admin_google_auth_service.py
@@ -245,3 +245,19 @@ async def test_rejects_inactive_admin_credential_and_does_not_link(monkeypatch: 
     with pytest.raises(UnauthorizedException):
         await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
     assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_linked_subject_whose_credential_is_no_longer_admin_eligible(monkeypatch: pytest.MonkeyPatch):
+    """A pre-existing Google link must fail the same generic way as every other rejection once its
+    credential is demoted/deactivated/unverified — not leak LoginService's distinct admin-portal message."""
+    service, user_repo, verifier = _build_service(monkeypatch)
+    admin = user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+    await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+    admin.is_admin = False  # demoted after the link was created
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == "Google sign-in failed"

--- a/tests/application/auth/test_admin_google_auth_service.py
+++ b/tests/application/auth/test_admin_google_auth_service.py
@@ -1,0 +1,247 @@
+"""
+Application-service seam: Admin Google ID-token sign-in (ADR 0006, stub verifier + stub repos).
+
+Happy path: a first success matching by verified email upserts a Google Identity
+link on an already admin-eligible Auth credential and returns the same admin
+login session shape as password login; a later success resolves by `sub` alone.
+Every rejection path (inactive provider, missing Client ID allowlist, invalid
+token, unverified email, non-admin-eligible credential) fails generically.
+"""
+
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.application.auth.admin_google_auth_service import AdminGoogleAuthService
+from portal.application.auth.commands import AdminGoogleLoginCommand
+from portal.application.auth.login_service import LoginService
+from portal.application.auth.results import LoginResult, UserSensitive
+from portal.domain.auth.entities import GoogleIdentityClaims
+from portal.exceptions.responses import UnauthorizedException
+
+ALLOWED_CLIENT_IDS = ["web-client-id"]
+
+
+class StubUserRepository:
+    def __init__(self):
+        self.by_email: dict[str, UserSensitive] = {}
+        self.by_id: dict[UUID, UserSensitive] = {}
+        self.identity_links: dict[tuple[str, str], UUID] = {}
+        self.link_calls: list[dict[str, Any]] = []
+        self.google_provider_active = True
+        self.last_login_updates: list[UUID] = []
+
+    def seed_admin(
+        self, *, email: str, is_admin: bool = True, verified: bool = True, is_active: bool = True, password_hash: Optional[str] = "hashed:pw"
+    ) -> UserSensitive:
+        user = UserSensitive(
+            id=uuid4(), email=email, password_hash=password_hash, verified=verified, is_active=is_active, is_admin=is_admin, first_name="Ada", last_name="Min"
+        )
+        self.by_email[email.strip().lower()] = user
+        self.by_id[user.id] = user
+        return user
+
+    async def identity_provider_is_active(self, code: str) -> bool:
+        assert code == "google"
+        return self.google_provider_active
+
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
+        return self.identity_links.get((provider, provider_subject))
+
+    async def upsert_identity_link(
+        self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
+    ) -> None:
+        self.link_calls.append({"user_id": user_id, "provider": provider, "provider_subject": provider_subject, "additional_data": additional_data})
+        self.identity_links[(provider, provider_subject)] = user_id
+
+    async def get_sensitive_by_email(self, email: str) -> Optional[UserSensitive]:
+        return self.by_email.get(email.strip().lower())
+
+    async def get_sensitive_by_id(self, user_id: UUID) -> Optional[UserSensitive]:
+        return self.by_id.get(user_id)
+
+    async def update_last_login_at(self, user_id: UUID, last_login_at) -> None:
+        self.last_login_updates.append(user_id)
+
+
+class StubGoogleIdTokenVerifier:
+    def __init__(self):
+        self.claims_by_token: dict[str, GoogleIdentityClaims] = {}
+
+    def register(self, token: str, claims: GoogleIdentityClaims) -> None:
+        self.claims_by_token[token] = claims
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[GoogleIdentityClaims]:
+        claims = self.claims_by_token.get(id_token)
+        if not claims or claims.audience not in audiences:
+            return None
+        return claims
+
+
+class StubJwtProvider:
+    def create_access_token(self, *args, **kwargs) -> str:
+        return "access-token"
+
+
+class StubRefreshTokenProvider:
+    async def issue(self, *, user_id: UUID, device_id: UUID, family_id: UUID) -> str:
+        return "refresh-token"
+
+
+class StubRoleService:
+    async def init_user_roles_cache(self, user: UserSensitive, expire: int) -> list[str]:
+        return ["admin"]
+
+
+class StubPermissionService:
+    async def init_user_permissions_cache(self, user: UserSensitive, expire: int) -> list[str]:
+        return []
+
+
+def _build_service(
+    monkeypatch: pytest.MonkeyPatch, client_ids: list[str] = ALLOWED_CLIENT_IDS
+) -> tuple[AdminGoogleAuthService, StubUserRepository, StubGoogleIdTokenVerifier]:
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "GOOGLE_ADMIN_CLIENT_IDS", ",".join(client_ids))
+
+    user_repo = StubUserRepository()
+    verifier = StubGoogleIdTokenVerifier()
+    login_service = LoginService(
+        user_repository=user_repo,
+        jwt_provider=StubJwtProvider(),
+        refresh_token_provider=StubRefreshTokenProvider(),
+        password_provider=None,
+        role_service=StubRoleService(),
+        permission_service=StubPermissionService(),
+    )
+    service = AdminGoogleAuthService(user_repository=user_repo, google_id_token_verifier=verifier, login_service=login_service)
+    return service, user_repo, verifier
+
+
+@pytest.mark.asyncio
+async def test_first_success_matches_verified_email_and_upserts_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    admin = user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="Admin@Example.com", email_verified=True, audience="web-client-id"))
+
+    result = await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+    assert isinstance(result, LoginResult)
+    assert result.admin.id == admin.id
+    assert result.token.access_token == "access-token"
+    assert result.token.refresh_token == "refresh-token"
+    assert user_repo.link_calls == [
+        {"user_id": admin.id, "provider": "google", "provider_subject": "google-sub-1", "additional_data": {"email": "Admin@Example.com"}}
+    ]
+    assert admin.password_hash == "hashed:pw"  # linking Google never clears password_hash
+
+
+@pytest.mark.asyncio
+async def test_later_success_resolves_by_subject_without_email_lookup(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    admin = user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+    await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+    # Remove the email match path entirely — only the Identity link should resolve the user now.
+    user_repo.by_email.clear()
+    verifier.register("token-2", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+
+    result = await service.login_with_google(AdminGoogleLoginCommand(id_token="token-2"))
+
+    assert result.admin.id == admin.id
+    assert len(user_repo.link_calls) == 1  # no re-upsert needed on subject-match path
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_provider_inactive(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="admin@example.com")
+    user_repo.google_provider_active = False
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_client_id_allowlist_empty(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch, client_ids=[])
+    user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_or_unverified_token(monkeypatch: pytest.MonkeyPatch):
+    service, _user_repo, _verifier = _build_service(monkeypatch)
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="not-a-registered-token"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_wrong_audience(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="other-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_unverified_email(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="admin@example.com")
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=False, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_credential_not_found_without_enumeration(monkeypatch: pytest.MonkeyPatch):
+    service, _user_repo, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="unknown@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+
+
+@pytest.mark.asyncio
+async def test_rejects_credential_not_admin_eligible_and_does_not_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="notadmin@example.com", is_admin=False)
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="notadmin@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_unverified_admin_credential_and_does_not_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="admin@example.com", verified=False)
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_inactive_admin_credential_and_does_not_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, verifier = _build_service(monkeypatch)
+    user_repo.seed_admin(email="admin@example.com", is_active=False)
+    verifier.register("token-1", GoogleIdentityClaims(subject="google-sub-1", email="admin@example.com", email_verified=True, audience="web-client-id"))
+
+    with pytest.raises(UnauthorizedException):
+        await service.login_with_google(AdminGoogleLoginCommand(id_token="token-1"))
+    assert user_repo.link_calls == []


### PR DESCRIPTION
## Summary

Admin console users can now exchange a verified Google ID token for the same admin JWT session (access + refresh) they get from password login, per ADR 0006. Resolution order: existing Google Identity link by `sub`, else verified email (case-insensitive) match to an admin-eligible Auth credential, upserting the link on first success. Google sign-in is gated on the `google` Identity provider being active **and** a configured Client ID allowlist. Every rejection path (inactive provider, missing allowlist, invalid/unverified/wrong-audience token, non-admin-eligible credential) returns the same generic failure — no account enumeration. Password login and existing password hashes are untouched; no Admin User or Auth credential is ever created from Google alone.

Closes #20

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `GoogleIdTokenVerifierPort` (domain) + `GoogleIdTokenVerifier` (infra, PyJWT + Google's published JWKS) keep signature/issuer/expiry/audience verification behind a seam, per the parent spec.
- `AdminGoogleAuthService` owns resolution/enablement/rejection logic and delegates token issuance to the existing `LoginService.complete_admin_login`, so the response shape matches password login exactly.
- `GOOGLE_ADMIN_CLIENT_IDS` (comma-separated, multi-value ready) is new env/secrets config; only the portal Web client needs to be configured for this ticket.
- New endpoint: `POST /admin/api/v1/auth/google`.
- Code review (standards + spec axes) surfaced one gap — a Google-linked account demoted/deactivated after linking leaked a different error message than every other rejection path — fixed by re-checking admin eligibility on the `sub`-resolution branch too, with a regression test.
- No Alembic files touched; no End-user or Admin Apple paths added.

## Testing

- [x] `uv run pytest` (76 passed)
- [x] `uv run ruff format --check` / `uv run ruff check` on touched files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge