### PR TITLE
feat(cli): add init-all one-shot bootstrap seed command

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ uv run alembic revision --autogenerate -m "description"
 uv run alembic upgrade head
 ```
 
+#### Seed Bootstrap Data
+
+```bash
+# One-shot: seed locale, identity provider, legal document, system setting, and
+# RBAC data, then interactively prompt for and create a superuser
+uv run rooted-cli init-all
+```
+
 ### 5. Run the Application
 
 #### Development Environment

--- a/portal/cli/init_all.py
+++ b/portal/cli/init_all.py
@@ -1,0 +1,24 @@
+"""
+Init-all CLI command: seed every kind of backend bootstrap data in one shot.
+"""
+
+import click
+
+from .init_locale import init_locales_process
+from .rbac import init_rbac_process
+from .seed_identity_providers import seed_identity_providers_process
+from .seed_legal_documents import seed_legal_documents_process
+from .seed_system_settings import seed_system_settings_process
+from .superuser import create_superuser_process
+
+
+def init_all_process() -> None:
+    """Seed locale, identity provider, legal document, system setting, and RBAC data, then create a superuser."""
+    click.echo(click.style("Running init-all...", fg="cyan"))
+    init_locales_process()
+    seed_identity_providers_process()
+    seed_legal_documents_process()
+    seed_system_settings_process()
+    init_rbac_process()
+    create_superuser_process()
+    click.echo(click.style("init-all complete.", fg="bright_green"))

--- a/portal/cli/main.py
+++ b/portal/cli/main.py
@@ -6,7 +6,13 @@ import click
 
 from .bible import dump_bible_process
 from .import_bible import import_bible_data_process
+from .init_all import init_all_process
+from .init_locale import init_locales_process
+from .rbac import init_rbac_process, reset_rbac_process
 from .seed_identity_providers import seed_identity_providers_process
+from .seed_legal_documents import seed_legal_documents_process
+from .seed_system_settings import seed_system_settings_process
+from .superuser import create_superuser_process
 
 
 @click.group()
@@ -64,6 +70,53 @@ def seed_identity_providers_cmd():
     seed_identity_providers_process()
 
 
+@cli.command(name="create-superuser")
+def create_superuser_cmd():
+    """Create a superuser account via interactive prompts."""
+    create_superuser_process()
+
+
+@cli.command(name="init-rbac")
+def init_rbac_cmd():
+    """Seed verbs, resources, permissions, roles, and role-permission mappings."""
+    init_rbac_process()
+
+
+@cli.command(name="reset-rbac")
+@click.option("--force", is_flag=True, default=False, help="Skip the IS_DEV guard and confirmation prompt.")
+def reset_rbac_cmd(force: bool):
+    """Delete all RBAC data and re-seed from rbac_seed_data."""
+    reset_rbac_process(force=force)
+
+
+@cli.command(name="init-locales")
+def init_locales_cmd():
+    """Seed locales into SystemLocale table."""
+    init_locales_process()
+
+
+@cli.command(name="seed-legal-documents")
+def seed_legal_documents_cmd():
+    """Seed content.legal_document rows (insert-if-missing)."""
+    seed_legal_documents_process()
+
+
+@cli.command(name="seed-system-settings")
+def seed_system_settings_cmd():
+    """Seed public.system_setting rows (insert-if-missing)."""
+    seed_system_settings_process()
+
+
+@cli.command(name="init-all")
+def init_all_cmd():
+    """Seed locale, identity provider, legal document, system setting, and RBAC data, then create a superuser."""
+    init_all_process()
+
+
 def main() -> int:
     cli()
     return 0
+
+
+if __name__ == "__main__":
+    main()

--- a/portal/cli/superuser.py
+++ b/portal/cli/superuser.py
@@ -8,6 +8,7 @@ import click
 
 from portal.application.cli.superuser_seed_service import SuperuserSeedService
 from portal.container import Container
+from portal.libs.logger import logger
 from portal.libs.shared import validator
 from portal.providers.password_provider import PasswordProvider
 
@@ -22,9 +23,10 @@ async def create_superuser(email: str, password: str, first_name: str, last_name
         service = SuperuserSeedService(session, PasswordProvider())
         return await service.run(email=email, password=password, first_name=first_name, last_name=last_name)
     except Exception as exc:
-        click.echo(f"Error creating superuser: {exc}")
         await session.rollback()
-        return None
+        click.echo(f"Error creating superuser: {exc}")
+        logger.exception(exc)
+        raise
     finally:
         await session.close()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,24 @@ dependencies = [
     "pillow",
     "aiosmtplib",
     "jinja2",
+    "click",
 ]
 
+[project.scripts]
+rooted-cli = "portal.cli.main:main"
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+include = ["portal*"]
+
 [dependency-groups]
-dev = ["alembic", "pytest", "pytest-asyncio", "pytest-mock", "click", "ruff"]
+dev = ["alembic", "pytest", "pytest-asyncio", "pytest-mock", "ruff"]
 
 [tool.uv]
-package = false
+package = true
 required-version = ">=0.12.4,<0.13"
 
 [tool.ruff]

--- a/tests/cli/test_init_all.py
+++ b/tests/cli/test_init_all.py
@@ -1,0 +1,43 @@
+"""
+init-all orchestration: fixed step order, fail-fast on the first error.
+"""
+
+import pytest
+
+from portal.cli import init_all
+
+
+def test_init_all_process_calls_steps_in_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(init_all, "init_locales_process", lambda: calls.append("locale"))
+    monkeypatch.setattr(init_all, "seed_identity_providers_process", lambda: calls.append("identity_provider"))
+    monkeypatch.setattr(init_all, "seed_legal_documents_process", lambda: calls.append("legal_document"))
+    monkeypatch.setattr(init_all, "seed_system_settings_process", lambda: calls.append("system_setting"))
+    monkeypatch.setattr(init_all, "init_rbac_process", lambda: calls.append("rbac"))
+    monkeypatch.setattr(init_all, "create_superuser_process", lambda: calls.append("superuser"))
+
+    init_all.init_all_process()
+
+    assert calls == ["locale", "identity_provider", "legal_document", "system_setting", "rbac", "superuser"]
+
+
+def test_init_all_process_stops_after_a_failing_step(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    monkeypatch.setattr(init_all, "init_locales_process", lambda: calls.append("locale"))
+    monkeypatch.setattr(init_all, "seed_identity_providers_process", lambda: calls.append("identity_provider"))
+
+    def failing_legal_document() -> None:
+        calls.append("legal_document")
+        raise RuntimeError("legal document seed failed")
+
+    monkeypatch.setattr(init_all, "seed_legal_documents_process", failing_legal_document)
+    monkeypatch.setattr(init_all, "seed_system_settings_process", lambda: calls.append("system_setting"))
+    monkeypatch.setattr(init_all, "init_rbac_process", lambda: calls.append("rbac"))
+    monkeypatch.setattr(init_all, "create_superuser_process", lambda: calls.append("superuser"))
+
+    with pytest.raises(RuntimeError, match="legal document seed failed"):
+        init_all.init_all_process()
+
+    assert calls == ["locale", "identity_provider", "legal_document"]

--- a/tests/cli/test_superuser.py
+++ b/tests/cli/test_superuser.py
@@ -1,0 +1,48 @@
+"""
+create_superuser: a failing seed must propagate (not swallow to None) after rollback.
+"""
+
+import pytest
+
+from portal.cli import superuser as superuser_module
+
+
+class _StubSession:
+    def __init__(self) -> None:
+        self.rollback_called = False
+        self.closed = False
+
+    async def rollback(self) -> None:
+        self.rollback_called = True
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+class _StubContainer:
+    def __init__(self, session: _StubSession) -> None:
+        self._session = session
+
+    def db_session(self) -> _StubSession:
+        return self._session
+
+
+class _RaisingSuperuserSeedService:
+    def __init__(self, *args, **kwargs) -> None:
+        pass
+
+    async def run(self, **kwargs):
+        raise RuntimeError("seed failed")
+
+
+@pytest.mark.asyncio
+async def test_create_superuser_propagates_exception_after_rollback(monkeypatch: pytest.MonkeyPatch) -> None:
+    session = _StubSession()
+    monkeypatch.setattr(superuser_module, "Container", lambda: _StubContainer(session))
+    monkeypatch.setattr(superuser_module, "SuperuserSeedService", _RaisingSuperuserSeedService)
+
+    with pytest.raises(RuntimeError, match="seed failed"):
+        await superuser_module.create_superuser(email="admin@example.com", password="password123", first_name="Ada", last_name="Min")
+
+    assert session.rollback_called is True
+    assert session.closed is True

--- a/uv.lock
+++ b/uv.lock
@@ -1040,12 +1040,13 @@ wheels = [
 [[package]]
 name = "rooted-core-api"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "aiosmtplib" },
     { name = "asyncpg" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
+    { name = "click" },
     { name = "cryptography" },
     { name = "dependency-injector" },
     { name = "email-validator" },
@@ -1078,7 +1079,6 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "alembic" },
-    { name = "click" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },
@@ -1091,6 +1091,7 @@ requires-dist = [
     { name = "asyncpg" },
     { name = "azure-storage-blob" },
     { name = "boto3" },
+    { name = "click" },
     { name = "cryptography", specifier = ">=47,<48" },
     { name = "dependency-injector" },
     { name = "email-validator" },
@@ -1123,7 +1124,6 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "alembic" },
-    { name = "click" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-mock" },


### PR DESCRIPTION
## Summary

Adds a single `uv run rooted-cli init-all` command that seeds locale, identity provider, legal document, system setting, and RBAC data, then interactively creates a superuser — in that fixed order, aborting immediately on the first failure. Also wires every previously-unwired seed/superuser command onto the CLI's click group and makes the whole CLI runnable for the first time (`uv run rooted-cli <command>`), which required setting `[tool.uv] package = true` plus a minimal setuptools `[build-system]` so uv actually installs the `[project.scripts]` entry point.

Closes #23

## Type of change

- [x] New feature or API
- [x] Bug fix (`create_superuser()` swallowed failures to `None`; now rolls back and raises, matching the other seed CLI modules' `rollback → logger.exception → raise` pattern)
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [x] Dependency or tooling (`click` moved from dev to main deps; `pyproject.toml` build-system added)

## Implementation notes

- `portal/cli/init_all.py` calls the six existing seed/superuser entry functions directly with no `try`/`except`, so a failure propagates and the interactive superuser prompt only runs after every non-interactive step succeeds.
- `reset-rbac`'s existing `--force` / `IS_DEV` / confirmation guard is unchanged, just wired onto the CLI group.
- Verified manually: `uv run rooted-cli --help` lists all 10 commands (`dump-bible`, `import-bible`, `seed-identity-providers`, `create-superuser`, `init-rbac`, `reset-rbac`, `init-locales`, `seed-legal-documents`, `seed-system-settings`, `init-all`).

## Testing

- [x] `uv run pytest` (79 passed)
- [x] `uv run ruff format --check` / `uv run ruff check` on changed files
- [x] Manual: `uv run rooted-cli --help` lists all commands

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge