### PR TITLE
fix(auth): serialize additional_data to JSON text before JSONB bind

### DIFF
--- a/portal/infrastructure/persistence/repositories/user_repository.py
+++ b/portal/infrastructure/persistence/repositories/user_repository.py
@@ -2,6 +2,7 @@
 User repository implementation (merged UserHandler + AdminUserHandler SQL).
 """
 
+import json
 from datetime import datetime, timezone
 from typing import Any, Optional
 from uuid import UUID, uuid4
@@ -128,6 +129,11 @@ class UserRepository:
     async def user_profile_exists(self, user_id: UUID) -> bool:
         profile_id = await self._session.select(AuthUserProfile.id).where(AuthUserProfile.user_id == user_id).fetchval()
         return bool(profile_id)
+
+    @staticmethod
+    def _serialize_jsonb(value: Optional[dict[str, Any]]) -> Optional[str]:
+        """asyncpg JSONB bind expects a JSON text string, not a raw Python value."""
+        return json.dumps(value) if value is not None else None
 
     def _active_identity_link_by_subject(self, provider: str, provider_subject: str, provider_tenant: Optional[str]):
         return (
@@ -435,7 +441,7 @@ class UserRepository:
                 await self.soft_delete_identity_link(user_id, provider)
             await (
                 self._session.update(AuthIdentityLink)
-                .values(user_id=user_id, additional_data=additional_data, updated_at=now, updated_by="identity_link")
+                .values(user_id=user_id, additional_data=self._serialize_jsonb(additional_data), updated_at=now, updated_by="identity_link")
                 .where(AuthIdentityLink.id == existing["id"])
                 .execute()
             )
@@ -454,7 +460,7 @@ class UserRepository:
                 .values(
                     provider_subject=provider_subject,
                     provider_tenant=provider_tenant,
-                    additional_data=additional_data,
+                    additional_data=self._serialize_jsonb(additional_data),
                     updated_at=now,
                     updated_by="identity_link",
                 )
@@ -471,7 +477,7 @@ class UserRepository:
                 provider=provider,
                 provider_tenant=provider_tenant,
                 provider_subject=provider_subject,
-                additional_data=additional_data,
+                additional_data=self._serialize_jsonb(additional_data),
                 is_deleted=False,
                 created_by="identity_link",
                 updated_by="identity_link",


### PR DESCRIPTION
## Summary

Admin Google ID-token sign-in was failing 500 every time because `upsert_identity_link` passed the raw Python `dict` for `additional_data` straight into the JSONB column bind. asyncpg's JSONB codec expects an already-serialized JSON string, not a raw dict. This mirrors the existing `SettingRepository._serialize_jsonb` fix for the same class of bug.

## Type of change

- [x] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

Added `UserRepository._serialize_jsonb`, applied at all three `additional_data` call sites in `upsert_identity_link` (existing-link-by-subject update, same-user-different-subject update, fresh insert). `None` passes through as `None` (SQL `NULL`) rather than being serialized to the string `"null"`, since `additional_data` is an optional column.

## Testing

- [x] `uv run pytest` (79 passed)
- [x] `uv run ruff check` / `uv run ruff format --diff` (clean)

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Closes #25