### PR TITLE
feat(push): device registration & lifecycle endpoint (#28)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -144,6 +144,22 @@ Client ↔ server reconciliation for v1 accounts — not a second product surfac
 
 ---
 
+### Push notifications
+
+**Device**:
+An app installation instance identified by a client-generated `device_key`, holding at most one push token and platform, and optionally linked to the **End user** currently signed in on it (nullable — overwritten on sign-in, cleared on sign-out). Exists independently of authentication: registered on first app launch, before any account exists, so an anonymous install can hold a Device row with no End user attached.
+_Avoid_: conflating with **End user** identity; assuming a Device belongs permanently to one account (a shared or re-logged-in device may change hands); Device Token (the token is a field on Device, not a separate concept)
+
+**Notification**:
+A single push-worthy event addressed to one **End user** (e.g. someone prayed for their prayer request). Delivered by fanning out to every active **Device** linked to that End user at send time.
+_Avoid_: conflating with the client-local daily reminder (`Preferences.reminder_enabled`/`reminder_time`), which never touches this concept — that reminder fires from an on-device schedule, not a server Notification row
+
+**Notification delivery**:
+One attempt to deliver a **Notification** to one specific **Device** — records success/failure and error detail. The basis for deactivating a Device whose token has permanently failed, so it stops being targeted by future Notifications.
+_Avoid_: a per-End-user read/unread inbox (not yet modeled — future work)
+
+---
+
 ## Version map (API relevance)
 
 | Phase | Backend focus                                      |

--- a/docs/adr/0007-direct-fcm-integration-not-expo-push-service.md
+++ b/docs/adr/0007-direct-fcm-integration-not-expo-push-service.md
@@ -1,0 +1,9 @@
+# Direct Firebase Admin SDK integration for push, not Expo Push Service
+
+`rooted-app` (the v1 client) is Expo React Native. Expo offers a hosted Expo Push Service that proxies delivery through FCM (Android) and APNs (iOS) and issues its own Expo-format push tokens — this is the path `rooted-docs` ADR-001 ("client-react-native") implies by naming "Expo Notifications" as the push mechanism.
+
+We decided instead to have `rooted-core-api` integrate directly with Firebase Cloud Messaging via the `firebase-admin` Python SDK, targeting native device tokens (FCM registration tokens on Android; APNs tokens registered into the Firebase project for iOS) rather than routing sends through Expo's hosted service. A Firebase project and service account already exist for this purpose.
+
+**Why:** direct control over the Firebase project (message targeting, delivery diagnostics, future use of other Firebase messaging features) without a dependency on Expo's push infrastructure or its token format.
+
+**Consequences:** `rooted-app` cannot obtain native tokens via the plain Expo-managed workflow — it must adopt a config plugin and `expo prebuild` to generate native `ios/`/`android/` projects (tracked as separate client-side tickets). The backend owns and stores real FCM/APNs tokens directly on `Device` rows (see `CONTEXT.md`), not Expo push tokens.

--- a/portal/application/push/__init__.py
+++ b/portal/application/push/__init__.py
@@ -1,0 +1,3 @@
+"""
+Push application services (Device registration & lifecycle).
+"""

--- a/portal/application/push/mappers.py
+++ b/portal/application/push/mappers.py
@@ -1,0 +1,10 @@
+"""
+Map push application results to API serializers.
+"""
+
+from portal.application.push.results import DeviceResult
+from portal.serializers.apis.v1.push import DeviceRegistration
+
+
+def device_to_api(result: DeviceResult) -> DeviceRegistration:
+    return DeviceRegistration.model_validate(result)

--- a/portal/application/push/push_service.py
+++ b/portal/application/push/push_service.py
@@ -7,6 +7,7 @@ from typing import Optional
 from uuid import UUID
 
 from portal.application.push.results import DeviceResult
+from portal.domain.app.ports import EndUserRepositoryPort
 from portal.domain.push.ports import DeviceRepositoryPort
 from portal.libs.tracing.distributed_trace import distributed_trace
 
@@ -14,8 +15,17 @@ from portal.libs.tracing.distributed_trace import distributed_trace
 class PushService:
     """Device registration & lifecycle use cases."""
 
-    def __init__(self, device_repository: DeviceRepositoryPort):
+    def __init__(self, device_repository: DeviceRepositoryPort, end_user_repository: EndUserRepositoryPort):
         self._device_repository = device_repository
+        self._end_user_repository = end_user_repository
+
+    @distributed_trace()
+    async def resolve_end_user_id(self, auth_user_id: Optional[UUID]) -> Optional[UUID]:
+        """Map an authenticated auth.user.id to its app.user.id (End user), or None when unauthenticated."""
+        if auth_user_id is None:
+            return None
+        end_user = await self._end_user_repository.get_by_auth_user_id(auth_user_id)
+        return end_user.id if end_user else None
 
     @distributed_trace()
     async def register_device(self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID]) -> DeviceResult:

--- a/portal/application/push/push_service.py
+++ b/portal/application/push/push_service.py
@@ -1,0 +1,29 @@
+"""
+Push application service.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID
+
+from portal.application.push.results import DeviceResult
+from portal.domain.push.ports import DeviceRepositoryPort
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+
+class PushService:
+    """Device registration & lifecycle use cases."""
+
+    def __init__(self, device_repository: DeviceRepositoryPort):
+        self._device_repository = device_repository
+
+    @distributed_trace()
+    async def register_device(self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID]) -> DeviceResult:
+        """
+        Upsert by device_key: unconditionally overwrite token/platform/app_version/
+        last_used_at, and set end_user_id to whatever this call resolved (the
+        signed-in End user's id, or None if unauthenticated).
+        """
+        return await self._device_repository.upsert_device(
+            device_key=device_key, token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=datetime.now(timezone.utc)
+        )

--- a/portal/application/push/results.py
+++ b/portal/application/push/results.py
@@ -1,0 +1,9 @@
+"""
+Push application results — aliases of domain read models.
+"""
+
+from portal.domain.push.entities import Device
+
+DeviceResult = Device
+
+__all__ = ["DeviceResult"]

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -54,7 +54,6 @@ class RootContainer(containers.DeclarativeContainer):
     bible_service = app.bible_service
     end_user_provisioning_service = app.end_user_provisioning_service
     app_auth_service = app.app_auth_service
-    end_user_repository = app.end_user_repository
     push_service = app.push_service
 
     event_bus = events.event_bus

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -54,6 +54,8 @@ class RootContainer(containers.DeclarativeContainer):
     bible_service = app.bible_service
     end_user_provisioning_service = app.end_user_provisioning_service
     app_auth_service = app.app_auth_service
+    end_user_repository = app.end_user_repository
+    push_service = app.push_service
 
     event_bus = events.event_bus
 

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -26,12 +26,12 @@ class AppContainer(containers.DeclarativeContainer):
     bible_repository = providers.Factory(BibleRepository, session=core.request_session)
     bible_service = providers.Factory(BibleService, bible_repository=bible_repository)
 
-    device_repository = providers.Factory(DeviceRepository, session=core.request_session)
-    push_service = providers.Factory(PushService, device_repository=device_repository)
-
     user_repository = providers.Factory(UserRepository, session=core.request_session)
     end_user_repository = providers.Factory(EndUserRepository, session=core.request_session)
     preferences_repository = providers.Factory(PreferencesRepository, session=core.request_session)
+
+    device_repository = providers.Factory(DeviceRepository, session=core.request_session)
+    push_service = providers.Factory(PushService, device_repository=device_repository, end_user_repository=end_user_repository)
     end_user_provisioning_service = providers.Factory(
         EndUserProvisioningService,
         user_repository=user_repository,

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -7,12 +7,14 @@ from dependency_injector import containers, providers
 from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
 from portal.application.auth.app_auth_service import AppAuthService
 from portal.application.bible.bible_service import BibleService
+from portal.application.push.push_service import PushService
 from portal.config import settings as app_settings
 from portal.domain.auth.member_web_app import MemberWebAppRegistry, parse_member_web_apps
 from portal.infrastructure.cache.magic_link_token_cache import MagicLinkTokenCache
 from portal.infrastructure.mail.magic_link_mailer import MagicLinkMailer
 from portal.infrastructure.persistence.repositories.app.end_user_repository import EndUserRepository, PreferencesRepository
 from portal.infrastructure.persistence.repositories.bible.bible_repository import BibleRepository
+from portal.infrastructure.persistence.repositories.push.device_repository import DeviceRepository
 from portal.infrastructure.persistence.repositories.user_repository import UserRepository
 
 
@@ -23,6 +25,9 @@ class AppContainer(containers.DeclarativeContainer):
 
     bible_repository = providers.Factory(BibleRepository, session=core.request_session)
     bible_service = providers.Factory(BibleService, bible_repository=bible_repository)
+
+    device_repository = providers.Factory(DeviceRepository, session=core.request_session)
+    push_service = providers.Factory(PushService, device_repository=device_repository)
 
     user_repository = providers.Factory(UserRepository, session=core.request_session)
     end_user_repository = providers.Factory(EndUserRepository, session=core.request_session)

--- a/portal/domain/push/__init__.py
+++ b/portal/domain/push/__init__.py
@@ -1,0 +1,3 @@
+"""
+Push notification bounded context (domain layer).
+"""

--- a/portal/domain/push/entities.py
+++ b/portal/domain/push/entities.py
@@ -1,0 +1,29 @@
+"""
+Push domain read model: Device (CONTEXT.md "Push notifications").
+"""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import Field
+
+from portal.domain.common.mixins import UUIDBaseModel
+
+
+class Device(UUIDBaseModel):
+    """
+    An app install identified by a client-generated device_key.
+
+    Holds at most one push token/platform, and is optionally linked to the
+    End user currently signed in on it (nullable — overwritten on sign-in,
+    cleared on sign-out).
+    """
+
+    device_key: str = Field(..., description="Client-generated device install key")
+    token: str = Field(..., description="Current push token (FCM/APNs-via-FCM)")
+    platform: str = Field(..., description="Platform: ios|android")
+    end_user_id: Optional[UUID] = Field(default=None, description="FK to app.user.id (End user); None when unauthenticated")
+    is_active: bool = Field(default=True, description="Whether this device should receive pushes")
+    last_used_at: datetime = Field(..., description="Last time this device registered/refreshed")
+    app_version: Optional[str] = Field(default=None, description="Client app version at last registration")

--- a/portal/domain/push/ports.py
+++ b/portal/domain/push/ports.py
@@ -1,0 +1,21 @@
+"""
+Ports for Device persistence.
+"""
+
+from datetime import datetime
+from typing import Optional, Protocol
+from uuid import UUID
+
+from portal.domain.push.entities import Device
+
+
+class DeviceRepositoryPort(Protocol):
+    """Persist push Device rows keyed by device_key."""
+
+    async def upsert_device(
+        self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID], last_used_at: datetime
+    ) -> Device:
+        """
+        Insert a Device on first registration, or overwrite token/platform/
+        app_version/last_used_at/end_user_id on every subsequent call.
+        """

--- a/portal/infrastructure/persistence/repositories/push/__init__.py
+++ b/portal/infrastructure/persistence/repositories/push/__init__.py
@@ -1,0 +1,3 @@
+"""
+Repository implementations for the push bounded context.
+"""

--- a/portal/infrastructure/persistence/repositories/push/device_repository.py
+++ b/portal/infrastructure/persistence/repositories/push/device_repository.py
@@ -1,0 +1,47 @@
+"""
+Device repository — SQLAlchemy-backed upsert by device_key.
+"""
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from portal.domain.push.entities import Device
+from portal.libs.database import Session
+from portal.models.push import PushDevice
+
+
+class DeviceRepository:
+    """Implements DeviceRepositoryPort via structural typing."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    async def upsert_device(
+        self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID], last_used_at: datetime
+    ) -> Device:
+        await (
+            self._session.insert(PushDevice)
+            .values(
+                id=uuid4(), device_key=device_key, token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=last_used_at
+            )
+            .on_conflict_do_update(
+                index_elements=["device_key"],
+                set_=dict(token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=last_used_at),
+            )
+            .execute()
+        )
+        return await (
+            self._session.select(
+                PushDevice.id,
+                PushDevice.device_key,
+                PushDevice.token,
+                PushDevice.platform,
+                PushDevice.end_user_id,
+                PushDevice.is_active,
+                PushDevice.last_used_at,
+                PushDevice.app_version,
+            )
+            .where(PushDevice.device_key == device_key)
+            .fetchrow(as_model=Device)
+        )

--- a/portal/libs/authorization/auth_config.py
+++ b/portal/libs/authorization/auth_config.py
@@ -4,7 +4,7 @@ Authentication and Authorization Configuration
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 class AuthConfig(BaseModel):
@@ -25,7 +25,16 @@ class AuthConfig(BaseModel):
 
     # Authentication configuration
     require_auth: bool = Field(default=True, description="Whether to require authentication (token verification)")
+    optional_auth: bool = Field(
+        default=False, description="When require_auth is False: verify Authorization header if present (401 on invalid/expired), else proceed unauthenticated"
+    )
     is_admin: bool = Field(default=False, description="Whether to use admin authentication (True) or user authentication (False)")
+
+    @model_validator(mode="after")
+    def _validate_auth_modes(self) -> "AuthConfig":
+        if self.require_auth and self.optional_auth:
+            raise ValueError("require_auth and optional_auth are mutually exclusive")
+        return self
 
     @field_validator("permission_codes")
     @classmethod

--- a/portal/middlewares/auth_middleware.py
+++ b/portal/middlewares/auth_middleware.py
@@ -54,7 +54,7 @@ class AuthMiddleware(BaseHTTPMiddleware):
         logger.debug(f"Auth config: {auth_config}")
         if auth_config:
             try:
-                if auth_config.require_auth:
+                if auth_config.require_auth or auth_config.optional_auth:
                     await self._authenticate(request, auth_config)
 
                 # Check permissions if required
@@ -157,6 +157,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         credentials: Optional[HTTPAuthorizationCredentials] = await self._http_bearer(request)
 
         if not credentials:
+            if auth_config.optional_auth:
+                # No Authorization header under optional_auth: proceed unauthenticated.
+                return
             raise UnauthorizedException(detail="Authentication required")
 
         token = credentials.credentials

--- a/portal/models/__init__.py
+++ b/portal/models/__init__.py
@@ -24,6 +24,7 @@ from .auth import (
 )
 from .bible import BibleBook, BibleVerse, BibleVersion
 from .content import ContentFile, ContentFileAssociation, ContentLegalDocument, ContentLegalDocumentTranslation
+from .push import PushDevice
 from .system_locale import SystemLocale
 from .system_setting import SystemSetting
 
@@ -65,4 +66,6 @@ __all__ = [
     "BibleBook",
     "BibleVerse",
     "BibleVersion",
+    # push
+    "PushDevice",
 ]

--- a/portal/models/push/__init__.py
+++ b/portal/models/push/__init__.py
@@ -1,0 +1,7 @@
+"""
+Push notification ORM models (push schema).
+"""
+
+from .device import PushDevice
+
+__all__ = ["PushDevice"]

--- a/portal/models/push/device.py
+++ b/portal/models/push/device.py
@@ -1,0 +1,36 @@
+"""
+Push device ORM: app install push registration (CONTEXT.md "Device").
+
+Exists independently of authentication: registered on first app launch,
+before any account exists, so an anonymous install can hold a Device row
+with no End user attached.
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import UUID
+
+from portal.libs.database.orm import ModelBase
+from portal.models.app.user import AppUser
+from portal.models.mixins import AuditMixin
+
+
+class PushDevice(ModelBase, AuditMixin):
+    """
+    An app install identified by a client-generated device_key.
+
+    Holds at most one push token/platform, and end_user_id is overwritten
+    on every registration call (bound on sign-in, cleared on sign-out).
+    """
+
+    __extra_table_args__ = (sa.UniqueConstraint("device_key"), {"comment": "Push notification device registrations"})
+
+    device_key = Column(sa.String(255), nullable=False, index=True, comment="Client-generated device install key")
+    token = Column(sa.Text, nullable=False, comment="Current push token (FCM/APNs-via-FCM)")
+    platform = Column(sa.String(10), nullable=False, comment="Platform: ios|android")
+    end_user_id = Column(
+        UUID, sa.ForeignKey(AppUser.id, ondelete="CASCADE"), nullable=True, index=True, comment="FK to app.user.id (End user); null when unauthenticated"
+    )
+    is_active = Column(sa.Boolean, nullable=False, server_default=sa.text("true"), comment="Whether this device should receive pushes")
+    last_used_at = Column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now(), comment="Last time this device registered/refreshed")
+    app_version = Column(sa.String(32), nullable=True, comment="Client app version at last registration")

--- a/portal/routers/apis/v1/__init__.py
+++ b/portal/routers/apis/v1/__init__.py
@@ -6,8 +6,10 @@ from fastapi import APIRouter
 
 from .auth import router as auth_router
 from .bible import router as bible_router
+from .push import router as push_router
 
 router = APIRouter()
 
 router.include_router(auth_router, prefix="/auth", tags=["Auth"])
 router.include_router(bible_router, prefix="/bible", tags=["Bible"])
+router.include_router(push_router, prefix="/push", tags=["Push"])

--- a/portal/routers/apis/v1/push.py
+++ b/portal/routers/apis/v1/push.py
@@ -1,0 +1,52 @@
+"""
+Push device API router.
+"""
+
+from dependency_injector.wiring import Provide, inject
+from fastapi import Depends
+from starlette import status
+
+from portal.application.push.mappers import device_to_api
+from portal.application.push.push_service import PushService
+from portal.container import Container
+from portal.domain.app.ports import EndUserRepositoryPort
+from portal.libs.contexts.user_context import get_user_context
+from portal.libs.depends.rate_limiters import WRITE_RATE_LIMITERS
+from portal.routers.auth_router import AuthRouter
+from portal.serializers.apis.v1.push import DeviceRegistration, DeviceRegistrationRequest
+
+router: AuthRouter = AuthRouter()
+
+
+@router.put(
+    "/devices/{device_key}",
+    response_model=DeviceRegistration,
+    response_model_by_alias=True,
+    status_code=status.HTTP_200_OK,
+    require_auth=False,
+    optional_auth=True,
+    dependencies=[*WRITE_RATE_LIMITERS],
+    operation_id="register_push_device",
+    summary="Register or refresh a push device",
+    description=(
+        "Upsert a push Device by device_key. Authorization is optional: when present it must verify "
+        "(invalid/expired tokens still 401), and end_user_id is always overwritten to whatever this call resolved."
+    ),
+)
+@inject
+async def register_device(
+    device_key: str,
+    body: DeviceRegistrationRequest,
+    push_service: PushService = Depends(Provide[Container.push_service]),
+    end_user_repository: EndUserRepositoryPort = Depends(Provide[Container.end_user_repository]),
+) -> DeviceRegistration:
+    user_context = get_user_context()
+    end_user_id = None
+    if user_context and user_context.user_id:
+        end_user = await end_user_repository.get_by_auth_user_id(user_context.user_id)
+        end_user_id = end_user.id if end_user else None
+
+    result = await push_service.register_device(
+        device_key=device_key, token=body.token, platform=body.platform, app_version=body.app_version, end_user_id=end_user_id
+    )
+    return device_to_api(result)

--- a/portal/routers/apis/v1/push.py
+++ b/portal/routers/apis/v1/push.py
@@ -9,7 +9,6 @@ from starlette import status
 from portal.application.push.mappers import device_to_api
 from portal.application.push.push_service import PushService
 from portal.container import Container
-from portal.domain.app.ports import EndUserRepositoryPort
 from portal.libs.contexts.user_context import get_user_context
 from portal.libs.depends.rate_limiters import WRITE_RATE_LIMITERS
 from portal.routers.auth_router import AuthRouter
@@ -35,16 +34,11 @@ router: AuthRouter = AuthRouter()
 )
 @inject
 async def register_device(
-    device_key: str,
-    body: DeviceRegistrationRequest,
-    push_service: PushService = Depends(Provide[Container.push_service]),
-    end_user_repository: EndUserRepositoryPort = Depends(Provide[Container.end_user_repository]),
+    device_key: str, body: DeviceRegistrationRequest, push_service: PushService = Depends(Provide[Container.push_service])
 ) -> DeviceRegistration:
     user_context = get_user_context()
-    end_user_id = None
-    if user_context and user_context.user_id:
-        end_user = await end_user_repository.get_by_auth_user_id(user_context.user_id)
-        end_user_id = end_user.id if end_user else None
+    auth_user_id = user_context.user_id if user_context else None
+    end_user_id = await push_service.resolve_end_user_id(auth_user_id)
 
     result = await push_service.register_device(
         device_key=device_key, token=body.token, platform=body.platform, app_version=body.app_version, end_user_id=end_user_id

--- a/portal/routers/auth_router.py
+++ b/portal/routers/auth_router.py
@@ -28,6 +28,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = False,
         require_auth: Optional[bool] = True,
+        optional_auth: Optional[bool] = False,
         is_admin: Optional[bool] = False,
         allow_superuser: Optional[bool] = False,
         *args,
@@ -41,6 +42,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param args:
@@ -49,6 +51,7 @@ class AuthRouter(APIRouter):
         self._permissions = permissions
         self._require_all = require_all
         self._require_auth = require_auth
+        self._optional_auth = optional_auth
         self._is_admin = is_admin
         self._allow_superuser = allow_superuser
 
@@ -122,6 +125,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = None,
         require_auth: Optional[bool] = None,
+        optional_auth: Optional[bool] = None,
         is_admin: Optional[bool] = None,
         allow_superuser: Optional[bool] = None,
         **kwargs,
@@ -132,6 +136,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param kwargs:
@@ -140,11 +145,12 @@ class AuthRouter(APIRouter):
 
         def decorator(func: Callable) -> Callable:
             auth_config = None
-            if require_auth or self._require_auth or permissions or self._permissions:
+            if require_auth or self._require_auth or optional_auth or self._optional_auth or permissions or self._permissions:
                 auth_config = AuthConfig(
                     permission_codes=permissions if permissions is not None else self._permissions,
                     require_all=require_all if require_all is not None else self._require_all,
                     require_auth=require_auth if require_auth is not None else self._require_auth,
+                    optional_auth=optional_auth if optional_auth is not None else self._optional_auth,
                     is_admin=is_admin if is_admin is not None else self._is_admin,
                     allow_superuser=allow_superuser if allow_superuser is not None else self._allow_superuser,
                 )
@@ -159,6 +165,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = None,
         require_auth: Optional[bool] = None,
+        optional_auth: Optional[bool] = None,
         is_admin: Optional[bool] = None,
         allow_superuser: Optional[bool] = None,
         **kwargs,
@@ -169,6 +176,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param kwargs:
@@ -177,11 +185,12 @@ class AuthRouter(APIRouter):
 
         def decorator(func: Callable) -> Callable:
             auth_config = None
-            if require_auth or self._require_auth or permissions or self._permissions:
+            if require_auth or self._require_auth or optional_auth or self._optional_auth or permissions or self._permissions:
                 auth_config = AuthConfig(
                     permission_codes=permissions if permissions is not None else self._permissions,
                     require_all=require_all if require_all is not None else self._require_all,
                     require_auth=require_auth if require_auth is not None else self._require_auth,
+                    optional_auth=optional_auth if optional_auth is not None else self._optional_auth,
                     is_admin=is_admin if is_admin is not None else self._is_admin,
                     allow_superuser=allow_superuser if allow_superuser is not None else self._allow_superuser,
                 )
@@ -196,6 +205,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = None,
         require_auth: Optional[bool] = None,
+        optional_auth: Optional[bool] = None,
         is_admin: Optional[bool] = None,
         allow_superuser: Optional[bool] = None,
         **kwargs,
@@ -206,6 +216,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param kwargs:
@@ -214,11 +225,12 @@ class AuthRouter(APIRouter):
 
         def decorator(func: Callable) -> Callable:
             auth_config = None
-            if require_auth or self._require_auth or permissions or self._permissions:
+            if require_auth or self._require_auth or optional_auth or self._optional_auth or permissions or self._permissions:
                 auth_config = AuthConfig(
                     permission_codes=permissions if permissions is not None else self._permissions,
                     require_all=require_all if require_all is not None else self._require_all,
                     require_auth=require_auth if require_auth is not None else self._require_auth,
+                    optional_auth=optional_auth if optional_auth is not None else self._optional_auth,
                     is_admin=is_admin if is_admin is not None else self._is_admin,
                     allow_superuser=allow_superuser if allow_superuser is not None else self._allow_superuser,
                 )
@@ -233,6 +245,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = None,
         require_auth: Optional[bool] = None,
+        optional_auth: Optional[bool] = None,
         is_admin: Optional[bool] = None,
         allow_superuser: Optional[bool] = None,
         **kwargs,
@@ -243,6 +256,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param kwargs:
@@ -251,11 +265,12 @@ class AuthRouter(APIRouter):
 
         def decorator(func: Callable) -> Callable:
             auth_config = None
-            if require_auth or self._require_auth or permissions or self._permissions:
+            if require_auth or self._require_auth or optional_auth or self._optional_auth or permissions or self._permissions:
                 auth_config = AuthConfig(
                     permission_codes=permissions if permissions is not None else self._permissions,
                     require_all=require_all if require_all is not None else self._require_all,
                     require_auth=require_auth if require_auth is not None else self._require_auth,
+                    optional_auth=optional_auth if optional_auth is not None else self._optional_auth,
                     is_admin=is_admin if is_admin is not None else self._is_admin,
                     allow_superuser=allow_superuser if allow_superuser is not None else self._allow_superuser,
                 )
@@ -270,6 +285,7 @@ class AuthRouter(APIRouter):
         permissions: Optional[List[str]] = None,
         require_all: Optional[bool] = None,
         require_auth: Optional[bool] = None,
+        optional_auth: Optional[bool] = None,
         is_admin: Optional[bool] = None,
         allow_superuser: Optional[bool] = None,
         **kwargs,
@@ -280,6 +296,7 @@ class AuthRouter(APIRouter):
         :param permissions:
         :param require_all:
         :param require_auth:
+        :param optional_auth: verify Authorization header when present, else proceed unauthenticated
         :param is_admin:
         :param allow_superuser:
         :param kwargs:
@@ -288,11 +305,12 @@ class AuthRouter(APIRouter):
 
         def decorator(func: Callable) -> Callable:
             auth_config = None
-            if require_auth or self._require_auth or permissions or self._permissions:
+            if require_auth or self._require_auth or optional_auth or self._optional_auth or permissions or self._permissions:
                 auth_config = AuthConfig(
                     permission_codes=permissions if permissions is not None else self._permissions,
                     require_all=require_all if require_all is not None else self._require_all,
                     require_auth=require_auth if require_auth is not None else self._require_auth,
+                    optional_auth=optional_auth if optional_auth is not None else self._optional_auth,
                     is_admin=is_admin if is_admin is not None else self._is_admin,
                     allow_superuser=allow_superuser if allow_superuser is not None else self._allow_superuser,
                 )

--- a/portal/serializers/apis/v1/push.py
+++ b/portal/serializers/apis/v1/push.py
@@ -1,0 +1,33 @@
+"""
+Member push device serializers (camelCase JSON via serialization_alias).
+"""
+
+from datetime import datetime
+from typing import Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, field_serializer
+
+
+class DeviceRegistrationRequest(BaseModel):
+    """Register or refresh a push device's token/platform."""
+
+    token: str = Field(..., description="Current push token (FCM/APNs-via-FCM)")
+    platform: Literal["ios", "android"] = Field(..., description="Platform: ios|android")
+    app_version: Optional[str] = Field(default=None, description="Client app version")
+
+
+class DeviceRegistration(BaseModel):
+    """Registered device state after upsert."""
+
+    id: UUID = Field(...)
+    device_key: str = Field(..., serialization_alias="deviceKey")
+    platform: str = Field(...)
+    end_user_id: Optional[UUID] = Field(default=None, serialization_alias="endUserId")
+    is_active: bool = Field(..., serialization_alias="isActive")
+    last_used_at: datetime = Field(..., serialization_alias="lastUsedAt")
+    app_version: Optional[str] = Field(default=None, serialization_alias="appVersion")
+
+    @field_serializer("id", "end_user_id")
+    def serialize_uuid(self, value: Optional[UUID], _info) -> Optional[str]:
+        return str(value) if value is not None else None

--- a/tests/application/push/test_push_service.py
+++ b/tests/application/push/test_push_service.py
@@ -1,0 +1,78 @@
+"""
+Tests for PushService.
+"""
+
+from uuid import uuid4
+
+import pytest
+
+from portal.application.push.push_service import PushService
+from portal.domain.push.entities import Device
+
+
+class StubDeviceRepository:
+    def __init__(self):
+        self.devices: dict[str, Device] = {}
+
+    async def upsert_device(self, *, device_key, token, platform, app_version, end_user_id, last_used_at):
+        existing = self.devices.get(device_key)
+        device = Device(
+            id=existing.id if existing else uuid4(),
+            device_key=device_key,
+            token=token,
+            platform=platform,
+            end_user_id=end_user_id,
+            is_active=existing.is_active if existing else True,
+            last_used_at=last_used_at,
+            app_version=app_version,
+        )
+        self.devices[device_key] = device
+        return device
+
+
+@pytest.mark.asyncio
+async def test_register_device_anonymous_leaves_end_user_id_none():
+    service = PushService(StubDeviceRepository())
+    result = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
+    assert result.end_user_id is None
+    assert result.device_key == "device-1"
+    assert result.token == "tok-1"
+    assert result.platform == "ios"
+    assert result.app_version == "1.0.0"
+    assert result.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_register_device_authenticated_sets_end_user_id():
+    end_user_id = uuid4()
+    service = PushService(StubDeviceRepository())
+    result = await service.register_device(device_key="device-1", token="tok-1", platform="android", app_version=None, end_user_id=end_user_id)
+    assert result.end_user_id == end_user_id
+
+
+@pytest.mark.asyncio
+async def test_reregistering_same_device_key_overwrites_previous_owner():
+    repository = StubDeviceRepository()
+    service = PushService(repository)
+    first_owner = uuid4()
+    first = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=first_owner)
+
+    second_owner = uuid4()
+    second = await service.register_device(device_key="device-1", token="tok-2", platform="ios", app_version="1.1.0", end_user_id=second_owner)
+
+    assert second.id == first.id
+    assert second.end_user_id == second_owner
+    assert second.token == "tok-2"
+    assert second.app_version == "1.1.0"
+
+
+@pytest.mark.asyncio
+async def test_reregistering_unauthenticated_after_sign_in_clears_end_user_id():
+    """Sign-out case: the client calls again without a bearer token, overwriting end_user_id back to None."""
+    repository = StubDeviceRepository()
+    service = PushService(repository)
+    await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=uuid4())
+
+    signed_out = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
+
+    assert signed_out.end_user_id is None

--- a/tests/application/push/test_push_service.py
+++ b/tests/application/push/test_push_service.py
@@ -7,6 +7,7 @@ from uuid import uuid4
 import pytest
 
 from portal.application.push.push_service import PushService
+from portal.domain.app.entities import EndUser
 from portal.domain.push.entities import Device
 
 
@@ -30,9 +31,20 @@ class StubDeviceRepository:
         return device
 
 
+class StubEndUserRepository:
+    def __init__(self, end_users: dict | None = None):
+        self._end_users = end_users or {}
+
+    async def create_end_user(self, *, end_user_id, auth_user_id):
+        raise NotImplementedError
+
+    async def get_by_auth_user_id(self, auth_user_id):
+        return self._end_users.get(auth_user_id)
+
+
 @pytest.mark.asyncio
 async def test_register_device_anonymous_leaves_end_user_id_none():
-    service = PushService(StubDeviceRepository())
+    service = PushService(StubDeviceRepository(), StubEndUserRepository())
     result = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
     assert result.end_user_id is None
     assert result.device_key == "device-1"
@@ -45,7 +57,7 @@ async def test_register_device_anonymous_leaves_end_user_id_none():
 @pytest.mark.asyncio
 async def test_register_device_authenticated_sets_end_user_id():
     end_user_id = uuid4()
-    service = PushService(StubDeviceRepository())
+    service = PushService(StubDeviceRepository(), StubEndUserRepository())
     result = await service.register_device(device_key="device-1", token="tok-1", platform="android", app_version=None, end_user_id=end_user_id)
     assert result.end_user_id == end_user_id
 
@@ -53,7 +65,7 @@ async def test_register_device_authenticated_sets_end_user_id():
 @pytest.mark.asyncio
 async def test_reregistering_same_device_key_overwrites_previous_owner():
     repository = StubDeviceRepository()
-    service = PushService(repository)
+    service = PushService(repository, StubEndUserRepository())
     first_owner = uuid4()
     first = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=first_owner)
 
@@ -70,9 +82,30 @@ async def test_reregistering_same_device_key_overwrites_previous_owner():
 async def test_reregistering_unauthenticated_after_sign_in_clears_end_user_id():
     """Sign-out case: the client calls again without a bearer token, overwriting end_user_id back to None."""
     repository = StubDeviceRepository()
-    service = PushService(repository)
+    service = PushService(repository, StubEndUserRepository())
     await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=uuid4())
 
     signed_out = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
 
     assert signed_out.end_user_id is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_end_user_id_returns_none_when_unauthenticated():
+    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    assert await service.resolve_end_user_id(None) is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_end_user_id_maps_auth_user_id_to_end_user_id():
+    auth_user_id = uuid4()
+    end_user = EndUser(id=uuid4(), auth_user_id=auth_user_id)
+    service = PushService(StubDeviceRepository(), StubEndUserRepository({auth_user_id: end_user}))
+
+    assert await service.resolve_end_user_id(auth_user_id) == end_user.id
+
+
+@pytest.mark.asyncio
+async def test_resolve_end_user_id_returns_none_when_auth_user_has_no_end_user():
+    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    assert await service.resolve_end_user_id(uuid4()) is None

--- a/tests/models/push/test_push_device_schema.py
+++ b/tests/models/push/test_push_device_schema.py
@@ -1,0 +1,28 @@
+"""ORM seam: push.device (Device) — CONTEXT.md "Push notifications"."""
+
+from portal.models import PushDevice
+
+
+def test_push_device_maps_to_push_device_table() -> None:
+    assert PushDevice.__table__.schema == "push"
+    assert PushDevice.__tablename__ == "device"
+    assert "device_key" in PushDevice.__table__.c
+    assert "token" in PushDevice.__table__.c
+    assert "platform" in PushDevice.__table__.c
+    assert "app_version" in PushDevice.__table__.c
+    assert "last_used_at" in PushDevice.__table__.c
+
+
+def test_push_device_end_user_id_is_nullable_fk_to_app_user() -> None:
+    end_user_id = PushDevice.__table__.c.end_user_id
+    assert end_user_id.nullable is True
+    assert end_user_id.foreign_keys
+    fk = next(iter(end_user_id.foreign_keys))
+    assert fk.column.table.fullname == "app.user"
+    assert fk.ondelete == "CASCADE"
+
+
+def test_push_device_is_active_defaults_true() -> None:
+    is_active = PushDevice.__table__.c.is_active
+    assert is_active.nullable is False
+    assert is_active.server_default is not None


### PR DESCRIPTION
## Summary

Adds `PUT /api/v1/push/devices/{device_key}`, an unconditional upsert keyed by `device_key`: `token`/`platform`/`app_version`/`last_used_at` are always overwritten, and `end_user_id` is always set to whatever the call resolved (the signed-in End user, or `None` when unauthenticated). This single rule covers anonymous registration, sign-in binding, app-reopen refresh, and sign-out detachment with one code path.

The endpoint accepts a bearer token that's optional but, when present, must still verify — invalid/expired tokens are never silently downgraded to anonymous. This required a new `optional_auth` mode on `AuthConfig`/`AuthMiddleware`/`AuthRouter` (mutually exclusive with the existing `require_auth`).

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- New `push` bounded context follows the `bible` vertical slice shape: `domain/push` (`Device` entity + `DeviceRepositoryPort`), `application/push` (`PushService`), `infrastructure/persistence/repositories/push` (`DeviceRepository`, upsert via `on_conflict_do_update`), `models/push` (ORM model, `push.device` table), and the HTTP router/serializers.
- `PushService.resolve_end_user_id` maps the request's `auth.user.id` (from `UserContext`) to `app.user.id` (End user) via the existing `EndUserRepositoryPort` — kept inside the application layer so the router only talks to `PushService`, not a repository directly (per this repo's `routers → application → domain` rule).
- Endpoint is protected by `WRITE_RATE_LIMITERS` as a no-auth write surface.
- **No Alembic migration included** — per `AGENTS.md`, migrations are human-managed. The `push.device` table needs to be created by a follow-up human-authored migration before this endpoint works against a real database; verified this by hitting the running endpoint locally and confirming everything up to the DB write path behaves correctly (auth/anon resolution), failing only on `relation "push.device" does not exist`.
- Known test gap (flagged per issue #28's own testing notes): there is no automated router/middleware-level test for the new `optional_auth` branch, since this repo has no existing precedent for that test tier. Verified manually instead: no `Authorization` header proceeds unauthenticated; an invalid bearer token 401s; a well-formed but unresolvable-user bearer token also 401s (never silently downgraded).
- Out of scope (tracked separately in #29): `Notification`/`NotificationDelivery`, `PushGatewayPort`, and `PushService.notify`.

## Testing

- [x] `uv run pytest` (89 passed)
- [x] `uv run ruff format` / `uv run ruff check --fix` on all changed files
- [x] Manual: live server smoke test of `PUT /api/v1/push/devices/{device_key}` for anonymous / invalid-token / unresolvable-user-token cases

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Closes #28