### PR TITLE
feat(push): notification send capability via FCM

### DIFF
--- a/example.env
+++ b/example.env
@@ -37,6 +37,9 @@ MAGIC_LINK_TOKEN_EXPIRE_MINUTES=15
 # Admin Google ID-token sign-in (ADR 0006) — comma-separated Client ID allowlist; empty disables Google admin sign-in
 GOOGLE_ADMIN_CLIENT_IDS=
 
+# Push notifications (ADR 0007) — Firebase service-account JSON, not a file path; empty disables push send
+FIREBASE_CREDENTIALS_JSON=
+
 # Logging
 SENSITIVE_PARAMS=password,token,secret
 

--- a/portal/application/push/push_service.py
+++ b/portal/application/push/push_service.py
@@ -6,18 +6,29 @@ from datetime import datetime, timezone
 from typing import Optional
 from uuid import UUID
 
-from portal.application.push.results import DeviceResult
+from portal.application.push.results import DeviceResult, NotificationResult
 from portal.domain.app.ports import EndUserRepositoryPort
-from portal.domain.push.ports import DeviceRepositoryPort
+from portal.domain.push.constants import DeliveryStatus, PushSendStatus
+from portal.domain.push.entities import NotificationDeliveryDraft
+from portal.domain.push.ports import DeviceRepositoryPort, NotificationRepositoryPort, PushGatewayPort
+from portal.libs.logger import logger
 from portal.libs.tracing.distributed_trace import distributed_trace
 
 
 class PushService:
-    """Device registration & lifecycle use cases."""
+    """Device registration & lifecycle, and Notification send, use cases."""
 
-    def __init__(self, device_repository: DeviceRepositoryPort, end_user_repository: EndUserRepositoryPort):
+    def __init__(
+        self,
+        device_repository: DeviceRepositoryPort,
+        end_user_repository: EndUserRepositoryPort,
+        notification_repository: NotificationRepositoryPort,
+        push_gateway: PushGatewayPort,
+    ):
         self._device_repository = device_repository
         self._end_user_repository = end_user_repository
+        self._notification_repository = notification_repository
+        self._push_gateway = push_gateway
 
     @distributed_trace()
     async def resolve_end_user_id(self, auth_user_id: Optional[UUID]) -> Optional[UUID]:
@@ -37,3 +48,49 @@ class PushService:
         return await self._device_repository.upsert_device(
             device_key=device_key, token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=datetime.now(timezone.utc)
         )
+
+    @distributed_trace()
+    async def notify(self, *, end_user_id: UUID, category: str, title: str, body: str, data: Optional[dict] = None) -> NotificationResult:
+        """
+        Create a Notification for an End user and fan it out to every active
+        Device it owns. Zero active devices is a valid no-op (the Notification
+        row is still created). Never raises to the caller — a gateway
+        exception becomes a failed NotificationDelivery per device instead.
+        """
+        notification = await self._notification_repository.create_notification(end_user_id=end_user_id, category=category, title=title, body=body, data=data)
+
+        devices = await self._device_repository.list_active_devices(end_user_id)
+        if not devices:
+            return notification
+
+        try:
+            send_results = await self._push_gateway.send_multicast(tokens=[device.token for device in devices], title=title, body=body, data=data)
+        except Exception as error:
+            logger.warning(f"Push gateway send_multicast failed for notification {notification.id}: {error}")
+            await self._notification_repository.record_deliveries(
+                [
+                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=str(error))
+                    for device in devices
+                ]
+            )
+            return notification
+
+        deliveries: list[NotificationDeliveryDraft] = []
+        unregistered_device_ids: list[UUID] = []
+        delivered_at = datetime.now(timezone.utc)
+        for device, result in zip(devices, send_results):
+            if result.status == PushSendStatus.SUCCESS:
+                deliveries.append(
+                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.SUCCESS, delivered_at=delivered_at)
+                )
+                continue
+
+            deliveries.append(NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=result.error))
+            if result.status == PushSendStatus.UNREGISTERED:
+                unregistered_device_ids.append(device.id)
+
+        await self._notification_repository.record_deliveries(deliveries)
+        if unregistered_device_ids:
+            await self._device_repository.deactivate_devices(unregistered_device_ids)
+
+        return notification

--- a/portal/application/push/results.py
+++ b/portal/application/push/results.py
@@ -2,8 +2,9 @@
 Push application results — aliases of domain read models.
 """
 
-from portal.domain.push.entities import Device
+from portal.domain.push.entities import Device, Notification
 
 DeviceResult = Device
+NotificationResult = Notification
 
-__all__ = ["DeviceResult"]
+__all__ = ["DeviceResult", "NotificationResult"]

--- a/portal/config.py
+++ b/portal/config.py
@@ -133,6 +133,9 @@ class Configuration(BaseSettings):
     # [Rate Limiting]
     RATE_LIMITERS_CONFIG: RateLimitersConfig | None = None
 
+    # [Push notifications — Firebase Cloud Messaging, ADR 0007. Service-account JSON, not a file path.]
+    FIREBASE_CREDENTIALS_JSON: str | None = os.getenv(key="FIREBASE_CREDENTIALS_JSON")
+
     # [Sentry]
     SENTRY_URL: str | None = os.getenv(key="SENTRY_URL")
 

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -15,6 +15,7 @@ from portal.infrastructure.mail.magic_link_mailer import MagicLinkMailer
 from portal.infrastructure.persistence.repositories.app.end_user_repository import EndUserRepository, PreferencesRepository
 from portal.infrastructure.persistence.repositories.bible.bible_repository import BibleRepository
 from portal.infrastructure.persistence.repositories.push.device_repository import DeviceRepository
+from portal.infrastructure.persistence.repositories.push.notification_repository import NotificationRepository
 from portal.infrastructure.persistence.repositories.user_repository import UserRepository
 
 
@@ -31,7 +32,14 @@ class AppContainer(containers.DeclarativeContainer):
     preferences_repository = providers.Factory(PreferencesRepository, session=core.request_session)
 
     device_repository = providers.Factory(DeviceRepository, session=core.request_session)
-    push_service = providers.Factory(PushService, device_repository=device_repository, end_user_repository=end_user_repository)
+    notification_repository = providers.Factory(NotificationRepository, session=core.request_session)
+    push_service = providers.Factory(
+        PushService,
+        device_repository=device_repository,
+        end_user_repository=end_user_repository,
+        notification_repository=notification_repository,
+        push_gateway=core.push_gateway,
+    )
     end_user_provisioning_service = providers.Factory(
         EndUserProvisioningService,
         user_repository=user_repository,

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -7,6 +7,7 @@ from dependency_injector import containers, providers
 from portal.config import settings
 from portal.libs.database import PostgresConnection, RedisPool, Session
 from portal.libs.database.session_proxy import SessionProxy
+from portal.providers.firebase_push_gateway import FirebasePushGateway
 from portal.providers.google_id_token_verifier import GoogleIdTokenVerifier
 from portal.providers.jwt_provider import JWTProvider
 from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
@@ -33,3 +34,4 @@ class CoreContainer(containers.DeclarativeContainer):
     password_provider = providers.Singleton(PasswordProvider)
     refresh_token_provider = providers.Factory(RefreshTokenProvider, session=request_session)
     google_id_token_verifier = providers.Singleton(GoogleIdTokenVerifier)
+    push_gateway = providers.Singleton(FirebasePushGateway, credentials_json=config.FIREBASE_CREDENTIALS_JSON)

--- a/portal/domain/push/constants.py
+++ b/portal/domain/push/constants.py
@@ -1,0 +1,21 @@
+"""
+Push domain constants.
+"""
+
+from enum import Enum
+
+
+class DeliveryStatus(str, Enum):
+    """NotificationDelivery.status — one attempt to deliver to one Device."""
+
+    PENDING = "pending"
+    SUCCESS = "success"
+    FAILED = "failed"
+
+
+class PushSendStatus(str, Enum):
+    """Per-token classification of a PushGatewayPort.send_multicast result."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    UNREGISTERED = "unregistered"

--- a/portal/domain/push/entities.py
+++ b/portal/domain/push/entities.py
@@ -1,14 +1,16 @@
 """
-Push domain read model: Device (CONTEXT.md "Push notifications").
+Push domain read models: Device, Notification, NotificationDelivery
+(CONTEXT.md "Push notifications").
 """
 
 from datetime import datetime
 from typing import Optional
 from uuid import UUID
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from portal.domain.common.mixins import UUIDBaseModel
+from portal.domain.push.constants import DeliveryStatus, PushSendStatus
 
 
 class Device(UUIDBaseModel):
@@ -27,3 +29,43 @@ class Device(UUIDBaseModel):
     is_active: bool = Field(default=True, description="Whether this device should receive pushes")
     last_used_at: datetime = Field(..., description="Last time this device registered/refreshed")
     app_version: Optional[str] = Field(default=None, description="Client app version at last registration")
+
+
+class Notification(UUIDBaseModel):
+    """A single push-worthy event addressed to one End user."""
+
+    end_user_id: UUID = Field(..., description="FK to app.user.id (End user) this Notification is addressed to")
+    category: str = Field(..., description="Free-form notification category")
+    title: str = Field(..., description="Notification title")
+    body: str = Field(..., description="Notification body")
+    data: Optional[dict] = Field(default=None, description="Optional structured payload")
+    created_at: datetime = Field(...)
+
+
+class NotificationDelivery(UUIDBaseModel):
+    """One attempt to deliver a Notification to one specific Device."""
+
+    notification_id: UUID = Field(..., description="FK to push.notification.id")
+    device_id: UUID = Field(..., description="FK to push.device.id")
+    status: DeliveryStatus = Field(...)
+    error: Optional[str] = Field(default=None, description="Failure detail, if any")
+    delivered_at: Optional[datetime] = Field(default=None)
+    created_at: datetime = Field(...)
+
+
+class NotificationDeliveryDraft(BaseModel):
+    """A NotificationDelivery row to be persisted, before an id is assigned."""
+
+    notification_id: UUID
+    device_id: UUID
+    status: DeliveryStatus
+    error: Optional[str] = None
+    delivered_at: Optional[datetime] = None
+
+
+class PushSendResult(BaseModel):
+    """One token's outcome from a PushGatewayPort.send_multicast call."""
+
+    token: str
+    status: PushSendStatus
+    error: Optional[str] = None

--- a/portal/domain/push/ports.py
+++ b/portal/domain/push/ports.py
@@ -1,12 +1,12 @@
 """
-Ports for Device persistence.
+Ports for Device, Notification, and PushGateway.
 """
 
 from datetime import datetime
 from typing import Optional, Protocol
 from uuid import UUID
 
-from portal.domain.push.entities import Device
+from portal.domain.push.entities import Device, Notification, NotificationDeliveryDraft, PushSendResult
 
 
 class DeviceRepositoryPort(Protocol):
@@ -18,4 +18,30 @@ class DeviceRepositoryPort(Protocol):
         """
         Insert a Device on first registration, or overwrite token/platform/
         app_version/last_used_at/end_user_id on every subsequent call.
+        """
+
+    async def list_active_devices(self, end_user_id: UUID) -> list[Device]:
+        """List every is_active Device belonging to an End user."""
+
+    async def deactivate_devices(self, device_ids: list[UUID]) -> None:
+        """Set is_active = false on the given Device ids."""
+
+
+class NotificationRepositoryPort(Protocol):
+    """Persist Notification and NotificationDelivery rows."""
+
+    async def create_notification(self, *, end_user_id: UUID, category: str, title: str, body: str, data: Optional[dict]) -> Notification:
+        """Create a Notification row addressed to an End user."""
+
+    async def record_deliveries(self, deliveries: list[NotificationDeliveryDraft]) -> None:
+        """Persist one NotificationDelivery row per attempted Device."""
+
+
+class PushGatewayPort(Protocol):
+    """Send a push message to a batch of device tokens."""
+
+    async def send_multicast(self, *, tokens: list[str], title: str, body: str, data: Optional[dict]) -> list[PushSendResult]:
+        """
+        Send one message to every token, returning one PushSendResult per
+        token in the same order as `tokens`.
         """

--- a/portal/infrastructure/persistence/repositories/push/device_repository.py
+++ b/portal/infrastructure/persistence/repositories/push/device_repository.py
@@ -6,6 +6,8 @@ from datetime import datetime
 from typing import Optional
 from uuid import UUID, uuid4
 
+import sqlalchemy as sa
+
 from portal.domain.push.entities import Device
 from portal.libs.database import Session
 from portal.models.push import PushDevice
@@ -13,6 +15,17 @@ from portal.models.push import PushDevice
 
 class DeviceRepository:
     """Implements DeviceRepositoryPort via structural typing."""
+
+    _DEVICE_COLUMNS = (
+        PushDevice.id,
+        PushDevice.device_key,
+        PushDevice.token,
+        PushDevice.platform,
+        PushDevice.end_user_id,
+        PushDevice.is_active,
+        PushDevice.last_used_at,
+        PushDevice.app_version,
+    )
 
     def __init__(self, session: Session):
         self._session = session
@@ -31,17 +44,16 @@ class DeviceRepository:
             )
             .execute()
         )
+        return await self._session.select(*self._DEVICE_COLUMNS).where(PushDevice.device_key == device_key).fetchrow(as_model=Device)
+
+    async def list_active_devices(self, end_user_id: UUID) -> list[Device]:
         return await (
-            self._session.select(
-                PushDevice.id,
-                PushDevice.device_key,
-                PushDevice.token,
-                PushDevice.platform,
-                PushDevice.end_user_id,
-                PushDevice.is_active,
-                PushDevice.last_used_at,
-                PushDevice.app_version,
-            )
-            .where(PushDevice.device_key == device_key)
-            .fetchrow(as_model=Device)
+            self._session.select(*self._DEVICE_COLUMNS)
+            .where(sa.and_(PushDevice.end_user_id == end_user_id, PushDevice.is_active.is_(True)))
+            .fetch(as_model=Device)
         )
+
+    async def deactivate_devices(self, device_ids: list[UUID]) -> None:
+        if not device_ids:
+            return
+        await self._session.update(PushDevice).values(is_active=False).where(PushDevice.id.in_(device_ids)).execute()

--- a/portal/infrastructure/persistence/repositories/push/notification_repository.py
+++ b/portal/infrastructure/persistence/repositories/push/notification_repository.py
@@ -1,0 +1,65 @@
+"""
+Notification repository — SQLAlchemy-backed create + delivery recording.
+"""
+
+import json
+from typing import Optional
+from uuid import UUID, uuid4
+
+from portal.domain.push.entities import Notification, NotificationDeliveryDraft
+from portal.libs.database import Session
+from portal.models.push import PushNotification, PushNotificationDelivery
+
+
+class NotificationRepository:
+    """Implements NotificationRepositoryPort via structural typing."""
+
+    def __init__(self, session: Session):
+        self._session = session
+
+    @staticmethod
+    def _serialize_jsonb(value: Optional[dict]) -> Optional[str]:
+        """asyncpg JSONB bind expects a JSON text string, not a raw Python value."""
+        return json.dumps(value) if value is not None else None
+
+    async def create_notification(self, *, end_user_id: UUID, category: str, title: str, body: str, data: Optional[dict]) -> Notification:
+        notification_id = uuid4()
+        await (
+            self._session.insert(PushNotification)
+            .values(id=notification_id, end_user_id=end_user_id, category=category, title=title, body=body, data=self._serialize_jsonb(data))
+            .execute()
+        )
+        return await (
+            self._session.select(
+                PushNotification.id,
+                PushNotification.end_user_id,
+                PushNotification.category,
+                PushNotification.title,
+                PushNotification.body,
+                PushNotification.data,
+                PushNotification.created_at,
+            )
+            .where(PushNotification.id == notification_id)
+            .fetchrow(as_model=Notification)
+        )
+
+    async def record_deliveries(self, deliveries: list[NotificationDeliveryDraft]) -> None:
+        if not deliveries:
+            return
+        await (
+            self._session.insert(PushNotificationDelivery)
+            .values(
+                [
+                    {
+                        "id": uuid4(),
+                        "notification_id": delivery.notification_id,
+                        "device_id": delivery.device_id,
+                        "status": delivery.status.value,
+                        "error": delivery.error,
+                        "delivered_at": delivery.delivered_at,
+                    }
+                    for delivery in deliveries
+                ]
+            )
+            .execute()
+        )

--- a/portal/models/__init__.py
+++ b/portal/models/__init__.py
@@ -24,7 +24,7 @@ from .auth import (
 )
 from .bible import BibleBook, BibleVerse, BibleVersion
 from .content import ContentFile, ContentFileAssociation, ContentLegalDocument, ContentLegalDocumentTranslation
-from .push import PushDevice
+from .push import PushDevice, PushNotification, PushNotificationDelivery
 from .system_locale import SystemLocale
 from .system_setting import SystemSetting
 
@@ -68,4 +68,6 @@ __all__ = [
     "BibleVersion",
     # push
     "PushDevice",
+    "PushNotification",
+    "PushNotificationDelivery",
 ]

--- a/portal/models/push/__init__.py
+++ b/portal/models/push/__init__.py
@@ -3,5 +3,7 @@ Push notification ORM models (push schema).
 """
 
 from .device import PushDevice
+from .notification import PushNotification
+from .notification_delivery import PushNotificationDelivery
 
-__all__ = ["PushDevice"]
+__all__ = ["PushDevice", "PushNotification", "PushNotificationDelivery"]

--- a/portal/models/push/notification.py
+++ b/portal/models/push/notification.py
@@ -1,0 +1,23 @@
+"""
+Notification ORM: a push-worthy event addressed to one End user (CONTEXT.md "Notification").
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from portal.libs.database.orm import ModelBase
+from portal.models.app.user import AppUser
+from portal.models.mixins import AuditCreatedAtMixin
+
+
+class PushNotification(ModelBase, AuditCreatedAtMixin):
+    """A single push-worthy event, fanned out to every active Device of end_user_id at send time."""
+
+    __extra_table_args__ = {"comment": "Push notifications addressed to an End user"}
+
+    end_user_id = Column(UUID, sa.ForeignKey(AppUser.id, ondelete="CASCADE"), nullable=False, index=True, comment="FK to app.user.id (End user)")
+    category = Column(sa.String(64), nullable=False, comment="Free-form notification category")
+    title = Column(sa.Text, nullable=False, comment="Notification title")
+    body = Column(sa.Text, nullable=False, comment="Notification body")
+    data = Column(JSONB, nullable=True, comment="Optional structured payload")

--- a/portal/models/push/notification_delivery.py
+++ b/portal/models/push/notification_delivery.py
@@ -1,0 +1,29 @@
+"""
+NotificationDelivery ORM: one delivery attempt of a Notification to one Device
+(CONTEXT.md "Notification delivery").
+"""
+
+import sqlalchemy as sa
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import UUID
+
+from portal.libs.database.orm import ModelBase
+from portal.models.mixins import AuditCreatedAtMixin
+from portal.models.push.device import PushDevice
+from portal.models.push.notification import PushNotification
+
+
+class PushNotificationDelivery(ModelBase, AuditCreatedAtMixin):
+    """
+    Records success/failure of sending one Notification to one Device.
+
+    The basis for deactivating a Device whose token has permanently failed.
+    """
+
+    __extra_table_args__ = (sa.UniqueConstraint("notification_id", "device_id"), {"comment": "Per-device delivery attempts for a Notification"})
+
+    notification_id = Column(UUID, sa.ForeignKey(PushNotification.id, ondelete="CASCADE"), nullable=False, index=True, comment="FK to push.notification.id")
+    device_id = Column(UUID, sa.ForeignKey(PushDevice.id, ondelete="CASCADE"), nullable=False, index=True, comment="FK to push.device.id")
+    status = Column(sa.String(16), nullable=False, server_default=sa.text("'pending'"), comment="Delivery status: pending|success|failed")
+    error = Column(sa.Text, nullable=True, comment="Failure detail, if any")
+    delivered_at = Column(sa.DateTime(timezone=True), nullable=True, comment="When delivery to this Device succeeded")

--- a/portal/providers/firebase_push_gateway.py
+++ b/portal/providers/firebase_push_gateway.py
@@ -1,0 +1,68 @@
+"""
+Firebase Cloud Messaging push gateway (ADR 0007 — direct FCM integration).
+"""
+
+import asyncio
+import json
+from typing import Optional
+
+import firebase_admin
+from firebase_admin import credentials, messaging
+
+from portal.domain.push.constants import PushSendStatus
+from portal.domain.push.entities import PushSendResult
+from portal.libs.logger import logger
+
+FCM_MULTICAST_TOKEN_LIMIT = 500
+
+
+class FirebasePushGateway:
+    """
+    Implements PushGatewayPort via firebase_admin.messaging.send_each_for_multicast.
+
+    Initializes the underlying Firebase App once, guarded against re-init
+    (firebase_admin raises if initialize_app is called twice for the same
+    default app, which would otherwise blow up on every DI construction).
+    """
+
+    def __init__(self, credentials_json: Optional[str]):
+        self._app = None
+        try:
+            self._app = firebase_admin.get_app()
+        except ValueError:
+            if not credentials_json:
+                logger.warning("FIREBASE_CREDENTIALS_JSON is not set; push notifications will fail until it is configured")
+                return
+            certificate = credentials.Certificate(json.loads(credentials_json))
+            self._app = firebase_admin.initialize_app(certificate)
+
+    async def send_multicast(self, *, tokens: list[str], title: str, body: str, data: Optional[dict]) -> list[PushSendResult]:
+        if self._app is None:
+            raise RuntimeError("Firebase push gateway is not configured (missing FIREBASE_CREDENTIALS_JSON)")
+
+        string_data = {key: str(value) for key, value in (data or {}).items()}
+        results: list[PushSendResult] = []
+        for start in range(0, len(tokens), FCM_MULTICAST_TOKEN_LIMIT):
+            batch = tokens[start : start + FCM_MULTICAST_TOKEN_LIMIT]
+            message = messaging.MulticastMessage(notification=messaging.Notification(title=title, body=body), data=string_data, tokens=batch)
+            try:
+                response = await asyncio.to_thread(messaging.send_each_for_multicast, message, app=self._app)
+            except Exception as error:
+                # A failure sending one batch must not discard already-sent batches' results.
+                logger.warning(f"FCM send_each_for_multicast failed for a batch of {len(batch)} tokens: {error}")
+                results.extend(PushSendResult(token=token, status=PushSendStatus.FAILED, error=str(error)) for token in batch)
+                continue
+            results.extend(self._classify(token, send_response) for token, send_response in zip(batch, response.responses))
+        return results
+
+    @staticmethod
+    def _classify(token: str, send_response: "messaging.SendResponse") -> PushSendResult:
+        if send_response.success:
+            return PushSendResult(token=token, status=PushSendStatus.SUCCESS)
+
+        error = send_response.exception
+        if isinstance(error, messaging.UnregisteredError):
+            return PushSendResult(token=token, status=PushSendStatus.UNREGISTERED, error=str(error))
+
+        logger.warning(f"FCM send failed for a token: {error}")
+        return PushSendResult(token=token, status=PushSendStatus.FAILED, error=str(error) if error else "unknown error")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "aiosmtplib",
     "jinja2",
     "click",
+    "firebase-admin>=7.5.0",
 ]
 
 [project.scripts]

--- a/tests/application/push/test_push_service.py
+++ b/tests/application/push/test_push_service.py
@@ -2,13 +2,15 @@
 Tests for PushService.
 """
 
+from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
 
 from portal.application.push.push_service import PushService
 from portal.domain.app.entities import EndUser
-from portal.domain.push.entities import Device
+from portal.domain.push.constants import DeliveryStatus, PushSendStatus
+from portal.domain.push.entities import Device, Notification, PushSendResult
 
 
 class StubDeviceRepository:
@@ -30,6 +32,14 @@ class StubDeviceRepository:
         self.devices[device_key] = device
         return device
 
+    async def list_active_devices(self, end_user_id):
+        return [device for device in self.devices.values() if device.end_user_id == end_user_id and device.is_active]
+
+    async def deactivate_devices(self, device_ids):
+        for device_key, device in self.devices.items():
+            if device.id in device_ids:
+                self.devices[device_key] = device.model_copy(update={"is_active": False})
+
 
 class StubEndUserRepository:
     def __init__(self, end_users: dict | None = None):
@@ -42,9 +52,47 @@ class StubEndUserRepository:
         return self._end_users.get(auth_user_id)
 
 
+class StubNotificationRepository:
+    def __init__(self):
+        self.notifications: list[Notification] = []
+        self.recorded_deliveries: list = []
+
+    async def create_notification(self, *, end_user_id, category, title, body, data):
+        notification = Notification(
+            id=uuid4(), end_user_id=end_user_id, category=category, title=title, body=body, data=data, created_at=datetime.now(timezone.utc)
+        )
+        self.notifications.append(notification)
+        return notification
+
+    async def record_deliveries(self, deliveries):
+        self.recorded_deliveries.extend(deliveries)
+
+
+class StubPushGateway:
+    def __init__(self, result_by_token: dict | None = None, raise_error: Exception | None = None):
+        self._result_by_token = result_by_token or {}
+        self._raise_error = raise_error
+        self.calls: list[dict] = []
+
+    async def send_multicast(self, *, tokens, title, body, data):
+        self.calls.append({"tokens": tokens, "title": title, "body": body, "data": data})
+        if self._raise_error:
+            raise self._raise_error
+        return [self._result_by_token.get(token, PushSendResult(token=token, status=PushSendStatus.SUCCESS)) for token in tokens]
+
+
+def make_push_service(device_repository=None, end_user_repository=None, notification_repository=None, push_gateway=None) -> PushService:
+    return PushService(
+        device_repository or StubDeviceRepository(),
+        end_user_repository or StubEndUserRepository(),
+        notification_repository or StubNotificationRepository(),
+        push_gateway or StubPushGateway(),
+    )
+
+
 @pytest.mark.asyncio
 async def test_register_device_anonymous_leaves_end_user_id_none():
-    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    service = make_push_service()
     result = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
     assert result.end_user_id is None
     assert result.device_key == "device-1"
@@ -57,7 +105,7 @@ async def test_register_device_anonymous_leaves_end_user_id_none():
 @pytest.mark.asyncio
 async def test_register_device_authenticated_sets_end_user_id():
     end_user_id = uuid4()
-    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    service = make_push_service()
     result = await service.register_device(device_key="device-1", token="tok-1", platform="android", app_version=None, end_user_id=end_user_id)
     assert result.end_user_id == end_user_id
 
@@ -65,7 +113,7 @@ async def test_register_device_authenticated_sets_end_user_id():
 @pytest.mark.asyncio
 async def test_reregistering_same_device_key_overwrites_previous_owner():
     repository = StubDeviceRepository()
-    service = PushService(repository, StubEndUserRepository())
+    service = make_push_service(device_repository=repository)
     first_owner = uuid4()
     first = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=first_owner)
 
@@ -82,7 +130,7 @@ async def test_reregistering_same_device_key_overwrites_previous_owner():
 async def test_reregistering_unauthenticated_after_sign_in_clears_end_user_id():
     """Sign-out case: the client calls again without a bearer token, overwriting end_user_id back to None."""
     repository = StubDeviceRepository()
-    service = PushService(repository, StubEndUserRepository())
+    service = make_push_service(device_repository=repository)
     await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=uuid4())
 
     signed_out = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
@@ -92,7 +140,7 @@ async def test_reregistering_unauthenticated_after_sign_in_clears_end_user_id():
 
 @pytest.mark.asyncio
 async def test_resolve_end_user_id_returns_none_when_unauthenticated():
-    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    service = make_push_service()
     assert await service.resolve_end_user_id(None) is None
 
 
@@ -100,12 +148,113 @@ async def test_resolve_end_user_id_returns_none_when_unauthenticated():
 async def test_resolve_end_user_id_maps_auth_user_id_to_end_user_id():
     auth_user_id = uuid4()
     end_user = EndUser(id=uuid4(), auth_user_id=auth_user_id)
-    service = PushService(StubDeviceRepository(), StubEndUserRepository({auth_user_id: end_user}))
+    service = make_push_service(end_user_repository=StubEndUserRepository({auth_user_id: end_user}))
 
     assert await service.resolve_end_user_id(auth_user_id) == end_user.id
 
 
 @pytest.mark.asyncio
 async def test_resolve_end_user_id_returns_none_when_auth_user_has_no_end_user():
-    service = PushService(StubDeviceRepository(), StubEndUserRepository())
+    service = make_push_service()
     assert await service.resolve_end_user_id(uuid4()) is None
+
+
+def _make_device(end_user_id, token="tok", is_active=True) -> Device:
+    return Device(
+        id=uuid4(), device_key=str(uuid4()), token=token, platform="ios", end_user_id=end_user_id, is_active=is_active, last_used_at=datetime.now(timezone.utc)
+    )
+
+
+@pytest.mark.asyncio
+async def test_notify_with_zero_active_devices_is_a_no_op():
+    notification_repository = StubNotificationRepository()
+    push_gateway = StubPushGateway()
+    service = make_push_service(notification_repository=notification_repository, push_gateway=push_gateway)
+    end_user_id = uuid4()
+
+    result = await service.notify(end_user_id=end_user_id, category="prayer", title="Someone prayed", body="body")
+
+    assert result.end_user_id == end_user_id
+    assert len(notification_repository.notifications) == 1
+    assert notification_repository.recorded_deliveries == []
+    assert push_gateway.calls == []
+
+
+@pytest.mark.asyncio
+async def test_notify_fans_out_to_every_active_device_and_skips_inactive():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    active_one = _make_device(end_user_id, token="tok-active-1")
+    active_two = _make_device(end_user_id, token="tok-active-2")
+    inactive = _make_device(end_user_id, token="tok-inactive", is_active=False)
+    other_user_device = _make_device(uuid4(), token="tok-other-user")
+    for device in (active_one, active_two, inactive, other_user_device):
+        device_repository.devices[device.device_key] = device
+
+    push_gateway = StubPushGateway()
+    service = make_push_service(device_repository=device_repository, push_gateway=push_gateway)
+
+    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+
+    assert set(push_gateway.calls[0]["tokens"]) == {"tok-active-1", "tok-active-2"}
+
+
+@pytest.mark.asyncio
+async def test_notify_records_success_and_failed_deliveries():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    ok_device = _make_device(end_user_id, token="tok-ok")
+    failing_device = _make_device(end_user_id, token="tok-fail")
+    device_repository.devices[ok_device.device_key] = ok_device
+    device_repository.devices[failing_device.device_key] = failing_device
+
+    notification_repository = StubNotificationRepository()
+    push_gateway = StubPushGateway(result_by_token={"tok-fail": PushSendResult(token="tok-fail", status=PushSendStatus.FAILED, error="boom")})
+    service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
+
+    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+
+    deliveries_by_device = {delivery.device_id: delivery for delivery in notification_repository.recorded_deliveries}
+    assert deliveries_by_device[ok_device.id].status == DeliveryStatus.SUCCESS
+    assert deliveries_by_device[failing_device.id].status == DeliveryStatus.FAILED
+    assert deliveries_by_device[failing_device.id].error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_notify_deactivates_device_classified_unregistered():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    unregistered_device = _make_device(end_user_id, token="tok-gone")
+    device_repository.devices[unregistered_device.device_key] = unregistered_device
+
+    notification_repository = StubNotificationRepository()
+    push_gateway = StubPushGateway(result_by_token={"tok-gone": PushSendResult(token="tok-gone", status=PushSendStatus.UNREGISTERED, error="not registered")})
+    service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
+
+    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+
+    assert device_repository.devices[unregistered_device.device_key].is_active is False
+    delivery = notification_repository.recorded_deliveries[0]
+    assert delivery.status == DeliveryStatus.FAILED
+    assert delivery.error == "not registered"
+
+
+@pytest.mark.asyncio
+async def test_notify_gateway_exception_records_failed_deliveries_and_does_not_raise():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    device = _make_device(end_user_id, token="tok-1")
+    device_repository.devices[device.device_key] = device
+
+    notification_repository = StubNotificationRepository()
+    push_gateway = StubPushGateway(raise_error=RuntimeError("FCM unavailable"))
+    service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
+
+    result = await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+
+    assert result is not None
+    assert len(notification_repository.recorded_deliveries) == 1
+    delivery = notification_repository.recorded_deliveries[0]
+    assert delivery.status == DeliveryStatus.FAILED
+    assert delivery.error == "FCM unavailable"
+    assert device_repository.devices[device.device_key].is_active is True

--- a/tests/models/push/test_push_notification_schema.py
+++ b/tests/models/push/test_push_notification_schema.py
@@ -1,0 +1,57 @@
+"""ORM seam: push.notification / push.notification_delivery (CONTEXT.md "Push notifications")."""
+
+from portal.models import PushNotification, PushNotificationDelivery
+
+
+def test_push_notification_maps_to_push_notification_table() -> None:
+    assert PushNotification.__table__.schema == "push"
+    assert PushNotification.__tablename__ == "notification"
+    assert "category" in PushNotification.__table__.c
+    assert "title" in PushNotification.__table__.c
+    assert "body" in PushNotification.__table__.c
+    assert "data" in PushNotification.__table__.c
+    assert "created_at" in PushNotification.__table__.c
+
+
+def test_push_notification_end_user_id_is_required_fk_to_app_user() -> None:
+    end_user_id = PushNotification.__table__.c.end_user_id
+    assert end_user_id.nullable is False
+    assert end_user_id.foreign_keys
+    fk = next(iter(end_user_id.foreign_keys))
+    assert fk.column.table.fullname == "app.user"
+    assert fk.ondelete == "CASCADE"
+
+
+def test_push_notification_delivery_maps_to_push_notification_delivery_table() -> None:
+    assert PushNotificationDelivery.__table__.schema == "push"
+    assert PushNotificationDelivery.__tablename__ == "notification_delivery"
+    assert "status" in PushNotificationDelivery.__table__.c
+    assert "error" in PushNotificationDelivery.__table__.c
+    assert "delivered_at" in PushNotificationDelivery.__table__.c
+    assert "created_at" in PushNotificationDelivery.__table__.c
+
+
+def test_push_notification_delivery_foreign_keys_cascade() -> None:
+    notification_id = PushNotificationDelivery.__table__.c.notification_id
+    device_id = PushNotificationDelivery.__table__.c.device_id
+    assert notification_id.nullable is False
+    assert device_id.nullable is False
+
+    notification_fk = next(iter(notification_id.foreign_keys))
+    assert notification_fk.column.table.fullname == "push.notification"
+    assert notification_fk.ondelete == "CASCADE"
+
+    device_fk = next(iter(device_id.foreign_keys))
+    assert device_fk.column.table.fullname == "push.device"
+    assert device_fk.ondelete == "CASCADE"
+
+
+def test_push_notification_delivery_unique_on_notification_and_device() -> None:
+    unique_constraints = [c for c in PushNotificationDelivery.__table__.constraints if c.__class__.__name__ == "UniqueConstraint"]
+    assert any({col.name for col in constraint.columns} == {"notification_id", "device_id"} for constraint in unique_constraints)
+
+
+def test_push_notification_delivery_status_defaults_pending() -> None:
+    status = PushNotificationDelivery.__table__.c.status
+    assert status.nullable is False
+    assert status.server_default is not None

--- a/uv.lock
+++ b/uv.lock
@@ -141,6 +141,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cachecontrol"
+version = "0.14.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f6/c972b32d80760fb79d6b9eeb0b3010a46b89c0b23cf6329417ff7886cd22/cachecontrol-0.14.4.tar.gz", hash = "sha256:e6220afafa4c22a47dd0badb319f84475d79108100d04e26e8542ef7d3ab05a1", size = 16150, upload-time = "2025-11-14T04:32:13.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/79/c45f2d53efe6ada1110cf6f9fca095e4ff47a0454444aefdde6ac4789179/cachecontrol-0.14.4-py3-none-any.whl", hash = "sha256:b7ac014ff72ee199b5f8af1de29d60239954f223e948196fa3d84adaffc71d2b", size = 22247, upload-time = "2025-11-14T04:32:11.733Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
@@ -440,6 +453,143 @@ wheels = [
 ]
 
 [[package]]
+name = "firebase-admin"
+version = "7.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachecontrol" },
+    { name = "google-api-core", extra = ["grpc"], marker = "platform_python_implementation != 'PyPy'" },
+    { name = "google-cloud-firestore", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "google-cloud-storage" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "pyjwt", extra = ["crypto"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/05/bc/769faa4e14d274a89d26c6e81337a279ce6ec795f885751db6b530e2784c/firebase_admin-7.5.0.tar.gz", hash = "sha256:6e2810cec954c6e69f21fd6dac9db152a0ba3fe11b7f8793830ad1e3a0032e20", size = 202138, upload-time = "2026-07-02T15:06:30.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/7e/718dc2599ec9a4e8cce37cd227fd4d4d998b5ac643660432316432b7cd9d/firebase_admin-7.5.0-py3-none-any.whl", hash = "sha256:a37383d9c2e406d82a660776679672bed74407fc50bde7aa1418ed436d0346b7", size = 141490, upload-time = "2026-07-02T15:06:28.967Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.36.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bf/d8/88c2f0e6b0dd46a7796cca64fad99c7adba2417916f5393e82b9b7d2548e/google_api_core-2.36.0.tar.gz", hash = "sha256:32779307b52e64c9a9592a3621de6281676ecaeea299fe8524e4637ab7ac2531", size = 196879, upload-time = "2026-09-03T22:30:51.216Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/56/30c91c61b8f70d4c09285a005b94798729aeaf4ec8b90c1c360da8207728/google_api_core-2.36.0-py3-none-any.whl", hash = "sha256:e4d0b179260727ea5c42222426d9199285214dbef7bf48f8b16600c7f9a78944", size = 184118, upload-time = "2026-09-03T22:30:06.662Z" },
+]
+
+[package.optional-dependencies]
+grpc = [
+    { name = "grpcio" },
+    { name = "grpcio-status" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.57.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/3a/d3982b28d267880b5641f9a32c55d8062a9d2bad2d28d0274285391c89c2/google_auth-2.57.1.tar.gz", hash = "sha256:eb47b230fc6707eed4aee1c9cef55ec05bc1785eecba74ff8b572d531e921b1e", size = 372426, upload-time = "2026-09-04T00:50:27.593Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/27/0f7247b8002a1404fdb5412aeb15fb0fe70288eb8f88a5873d1c0d8262cf/google_auth-2.57.1-py3-none-any.whl", hash = "sha256:ab439dee60a6856412bc058f13a68eb6a59c5b81526bb89cfdcf89ce9c0a48c9", size = 259974, upload-time = "2026-09-04T00:50:21.693Z" },
+]
+
+[[package]]
+name = "google-cloud-core"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f9/54/790548b190cff9cf07225c811d2668eacd8f2cbf04114475cbe3e5738752/google_cloud_core-2.7.0.tar.gz", hash = "sha256:874aaf89765db87a9b911b7a2ca7c5068554868eed9e75c7766affe342a2913d", size = 36603, upload-time = "2026-08-25T19:18:43.076Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/64/904dbc9bee128e7b87eeb60da67c8fa4d1a8acdc9a45dd2fedca67ef184d/google_cloud_core-2.7.0-py3-none-any.whl", hash = "sha256:c18a250904cfdda021eb3ae8b8238c9f9ca272a4cbbfb5cba946b3fe3022eed1", size = 31046, upload-time = "2026-08-24T21:55:28.36Z" },
+]
+
+[[package]]
+name = "google-cloud-firestore"
+version = "2.30.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core", extra = ["grpc"] },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "grpcio" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ca/ec/5d88afbf5b0a06f68fe632cfe0729d39ef3f26468334d03be7705a873ab5/google_cloud_firestore-2.30.0.tar.gz", hash = "sha256:4959011b0dba6c71c056653ace1caef362169475314eddb036683010e99d98eb", size = 658312, upload-time = "2026-09-03T22:31:11.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/67/c0ccbec09c76f0750d736c0138d7380f9693c8fa8e8a33babc6ce6e50556/google_cloud_firestore-2.30.0-py3-none-any.whl", hash = "sha256:85098db598fbd8747efd2265836152f2f05abfb2b6e1c001a31cdce0964ba447", size = 436499, upload-time = "2026-09-03T22:30:32.085Z" },
+]
+
+[[package]]
+name = "google-cloud-storage"
+version = "3.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-api-core" },
+    { name = "google-auth" },
+    { name = "google-cloud-core" },
+    { name = "google-crc32c" },
+    { name = "google-resumable-media" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ce/7e/73bb7512df1d1aad6ce3f9aed847cd40e0cd400ba4a85d86ab8eb412e9cc/google_cloud_storage-3.13.1.tar.gz", hash = "sha256:a80bf8cac2794808aa61c50c5f769ecbbe2d10331bacd0d69d30e59b14b346b2", size = 17341051, upload-time = "2026-08-06T06:24:42.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/6f/d69f0e185e08ddb58c323a0a935af2b492907b5de362bc08933b0a3b5644/google_cloud_storage-3.13.1-py3-none-any.whl", hash = "sha256:98208de6c21e85cecd3eb44551894efff33d98365500e178867d4305854a770a", size = 341486, upload-time = "2026-08-06T06:23:36.548Z" },
+]
+
+[[package]]
+name = "google-crc32c"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/41/4b9c02f99e4c5fb477122cd5437403b552873f014616ac1d19ac8221a58d/google_crc32c-1.8.0.tar.gz", hash = "sha256:a428e25fb7691024de47fecfbff7ff957214da51eddded0da0ae0e0f03a2cf79", size = 14192, upload-time = "2025-12-16T00:35:25.142Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/88/8ecf3c2b864a490b9e7010c84fd203ec8cf3b280651106a3a74dd1b0ca72/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_arm64.whl", hash = "sha256:e6584b12cb06796d285d09e33f63309a09368b9d806a551d8036a4207ea43697", size = 31301, upload-time = "2025-12-16T00:24:48.527Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c6/f7ff6c11f5ca215d9f43d3629163727a272eabc356e5c9b2853df2bfe965/google_crc32c-1.8.0-cp314-cp314-macosx_12_0_x86_64.whl", hash = "sha256:f4b51844ef67d6cf2e9425983274da75f18b1597bb2c998e1c0a0e8d46f8f651", size = 30868, upload-time = "2025-12-16T00:48:12.163Z" },
+    { url = "https://files.pythonhosted.org/packages/56/15/c25671c7aad70f8179d858c55a6ae8404902abe0cdcf32a29d581792b491/google_crc32c-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b0d1a7afc6e8e4635564ba8aa5c0548e3173e41b6384d7711a9123165f582de2", size = 33381, upload-time = "2025-12-16T00:40:26.268Z" },
+    { url = "https://files.pythonhosted.org/packages/42/fa/f50f51260d7b0ef5d4898af122d8a7ec5a84e2984f676f746445f783705f/google_crc32c-1.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8b3f68782f3cbd1bce027e48768293072813469af6a61a86f6bb4977a4380f21", size = 33734, upload-time = "2025-12-16T00:40:27.028Z" },
+    { url = "https://files.pythonhosted.org/packages/08/a5/7b059810934a09fb3ccb657e0843813c1fee1183d3bc2c8041800374aa2c/google_crc32c-1.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:d511b3153e7011a27ab6ee6bb3a5404a55b994dc1a7322c0b87b29606d9790e2", size = 34878, upload-time = "2025-12-16T00:35:23.142Z" },
+]
+
+[[package]]
+name = "google-resumable-media"
+version = "2.10.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-crc32c" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/4b/44e128cd7b0e72cd26da4a3052cd8a9ef1b5a890be7c611558067ea0b354/google_resumable_media-2.10.2.tar.gz", hash = "sha256:1de441703cd298d75a419bfdc0066e9fc7b0a1de630df96eea8ce8f5c759358c", size = 2164918, upload-time = "2026-08-25T19:19:11.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/30/3e976681b5319715ab022363f58f6f8e10f546a1777756fe3ebd918857e4/google_resumable_media-2.10.2-py3-none-any.whl", hash = "sha256:e3cedc827a4ea41e216582d74346f1fb9fceb625a8c3c53912f2ca1d663334d7", size = 81531, upload-time = "2026-08-25T19:18:07.193Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c5/4353a188e2c335aee33269e8b654af228278cca8e5f0b4b5f11e5d0e9adb/googleapis_common_protos-1.75.3.tar.gz", hash = "sha256:57c435ac2c68b108999b6db075d9053e4d7a936ba57b4a3d45667b1346f1738a", size = 153905, upload-time = "2026-09-03T22:31:21.869Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/7a/7d79170c6ce6f12e109df2b3879d6b934010cf4f99aea8de8b7e5408c174/googleapis_common_protos-1.75.3-py3-none-any.whl", hash = "sha256:a018d2bf098ca9fb6faa08d5bb780e2a2c2f73c566f069761331386c9596d3f2", size = 306984, upload-time = "2026-09-03T22:30:45.133Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.5"
 source = { registry = "https://pypi.org/simple" }
@@ -479,6 +629,41 @@ wheels = [
 ]
 
 [[package]]
+name = "grpcio"
+version = "1.83.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/b1/46539f5050d7c316a13396d185451f95084a74ddc68b12d818595bef0377/grpcio-1.83.1.tar.gz", hash = "sha256:9cee6fcbf2eb57c4b49451787bfa87be8efc1ca02a0b327dd4b54d44502e362b", size = 13445033, upload-time = "2026-08-28T07:09:11.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/9c/484d981d8b90c4e6abf3030bd2ed747e84d1eb192b3ec9cbb41e0b73e4bf/grpcio-1.83.1-cp314-cp314-linux_armv7l.whl", hash = "sha256:8b3c87ca908296bf125f841d3e1a2225a2b39aaa8ed7a57e7ccde465ee519bab", size = 6306089, upload-time = "2026-08-28T07:08:48.379Z" },
+    { url = "https://files.pythonhosted.org/packages/84/01/0afec1c92e4f292f74a44ecf75eabbf40903125b8c4df103c9868d6338da/grpcio-1.83.1-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:c0f3f20c90e72a171917ae65706500b096a1c3eb5f162c3ce702a2e25635f132", size = 12170381, upload-time = "2026-08-28T07:08:50.653Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/5a/e9a2383804433a0a61d6d93777ad321c7f36ac1cfdaa4c6d1a7c9ac846b7/grpcio-1.83.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:81bbf35a46bf8cad2dfbb2eccc19c711befb58b288acb534bbcd0d74283202a6", size = 6883286, upload-time = "2026-08-28T07:08:53.654Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/f8ca8f76994e14c70b9a0052e82f10de497a23db450c36379c9716ebfc4d/grpcio-1.83.1-cp314-cp314-manylinux2014_i686.manylinux_2_17_i686.whl", hash = "sha256:215cec07d11176507387bda4bf2751816e880f9bff8dc1ca524bfbb8ed8f2fad", size = 7624293, upload-time = "2026-08-28T07:08:55.709Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/7a/4b672814b0cd0fe63bdd735379d88b165759f3144ab023ad8ec5fc4d53ac/grpcio-1.83.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:abce7d43ec29cd39230fa8339de1a07643b55adc412a454850fbd875349950ff", size = 7044346, upload-time = "2026-08-28T07:08:57.802Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b8/d89fe60e4239ad51be333dd9cc703741d449a35064e51f8a0b5bfa755432/grpcio-1.83.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e256f95a40e3b0183a98556fb7164d24b97eeb353123ccabfcba94712b35ee2a", size = 7584187, upload-time = "2026-08-28T07:08:59.867Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/b2/b290d7402633d9166e4dd47e6f5f74a24ce10a8340b84455896ebc349f85/grpcio-1.83.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:2110059146fb0ea216e1ffddb29377b5cc2fd412a5b0a92e102616bd5edf18c2", size = 8608730, upload-time = "2026-08-28T07:09:02.592Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/44/fa89e44d1b5cf5b9fa71b2fd7abf506f182fd43917231a92fbf1ea326b02/grpcio-1.83.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20d944d967843f8183f9f23d5916388362e5f8eeeae855bbe4354d906dc9f31b", size = 7983283, upload-time = "2026-08-28T07:09:05.087Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/b8/9db73ed1f35ffa76124ac574bf296d06a359798dfd6b50d382f2b8a060a1/grpcio-1.83.1-cp314-cp314-win32.whl", hash = "sha256:623c87c6d4a1cb30d82c4e896f95477050f2e01b4a1f8cf91ff2b1abdf89c457", size = 4474327, upload-time = "2026-08-28T07:09:07.179Z" },
+    { url = "https://files.pythonhosted.org/packages/65/22/fc9a622d885a7a37ff972a12faaef443d74e47407181da70d0ab62ab41f0/grpcio-1.83.1-cp314-cp314-win_amd64.whl", hash = "sha256:47e6934ad38779271e2e7cc5f78a63a407cf3d98114c65c1fdbcd3f5a716f29b", size = 5302032, upload-time = "2026-08-28T07:09:09.285Z" },
+]
+
+[[package]]
+name = "grpcio-status"
+version = "1.83.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "grpcio" },
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/03/dee41fe15a9657c60397c1f215622a1f146e174367bbbb67911b62ee0629/grpcio_status-1.83.1.tar.gz", hash = "sha256:c08c8d553d6ab96effae1d923839de22926f5a316a942f48a48040e047c517af", size = 13957, upload-time = "2026-08-28T07:12:25.893Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/34/b03ec688e5c8c6ce283ec8b214d9c171e97059eb55157465f6fd6db1562c/grpcio_status-1.83.1-py3-none-any.whl", hash = "sha256:2cd328ee62ef2b3eb957dd3b75db7dadcdbb76488fdc9ab3aba1ebfbbdc324a4", size = 14636, upload-time = "2026-08-28T07:12:15.982Z" },
+]
+
+[[package]]
 name = "gunicorn"
 version = "25.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -497,6 +682,28 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "h2"
+version = "4.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e7/85/7c366e69d84c17bb778fe41419e1fbcce3033d5b7ce29bbffff0a98b859f/h2-4.4.1.tar.gz", hash = "sha256:4e866ffb1a869ae14dd9b5e6beb5c24a13da0495ad72b65925ded182521c1516", size = 2157281, upload-time = "2026-08-03T11:45:09.509Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/22/e85faf23bd72a92d1921e37d674ca56eb298a3c8be31fdecef0ff2b3aaac/h2-4.4.1-py3-none-any.whl", hash = "sha256:0e25f1462b23c9cb82d9eb02e28bc706dac2a68cb457c6a0d74d63c8a2a5d0e6", size = 62636, upload-time = "2026-08-03T11:44:59.164Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/5b/fcabf6028144a8723726318b07a32c2f3314acdff6265743cf08a344b18e/hpack-4.2.0.tar.gz", hash = "sha256:0895cfa3b5531fc65fe439c05eb65144f123bf7a394fcaa56aa423548d8e45c0", size = 51300, upload-time = "2026-06-23T18:34:46.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/b4/4a9fcfb2aef6ba44d9073ecd301443aa00b3dac95de5619f2a7de7ec8a91/hpack-4.2.0-py3-none-any.whl", hash = "sha256:858ac0b02280fa582b5080d68db0899c62a80375e0e5413a74970c5e518b6986", size = 34246, upload-time = "2026-06-23T18:34:45.472Z" },
 ]
 
 [[package]]
@@ -525,6 +732,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[package.optional-dependencies]
+http2 = [
+    { name = "h2" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]
@@ -618,6 +839,58 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/ea2100ec54d30c46ee9dba10a3bfb79b655e96c6df237238a3234c75869b/msgpack-1.2.2.tar.gz", hash = "sha256:9eb0b0e602064527a045ea28c4f174ed69383587e29cebe28947e3b84106eb2a", size = 187025, upload-time = "2026-08-27T10:03:47.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5e/50/3e92c403346652cabd08cb8faceef847bae917ea3b3c81b64a5b6d09ed41/msgpack-1.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e497ee34e8a3342bbde51b27c22d8db05a651df3361dd3daef5b3ab0d66f3e04", size = 84315, upload-time = "2026-08-27T10:02:41.181Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/8efe6dd96a12ab043930cb4cffb40b6e7f061491d6ec7a3d2b75ef1fda42/msgpack-1.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:0dd9173c5ebaf5ecc5ca86e7ae1db92934e1d57b856f3dd90698941431f4fd77", size = 84634, upload-time = "2026-08-27T10:02:42.621Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/89/996573095bf7b038c04dd65ddbc4f1a4d381b0f7a44ff9186f3c7b8325c2/msgpack-1.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8dc4487097571f7311188c3eca2a3e86cd1f1db4c37c7a017bcc3fd38486cbfe", size = 404194, upload-time = "2026-08-27T10:02:44.096Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/4e/46f5a5d949dbd054dab60cb15aac7ac6ae6774c134532893414689bf2f53/msgpack-1.2.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:73b0e05c32c3cfc3cd84994908e57430c0ebc6813abf905d3f18ff115d54df3f", size = 412343, upload-time = "2026-08-27T10:02:45.747Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e8/739a94197358a313307e6e9e7d8d22ef66add39222de911a44161aa96920/msgpack-1.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aa1120c653b76d8eafa50423b5eba06b5c9737f8692c74fa3afe03e84b8978ea", size = 372620, upload-time = "2026-08-27T10:02:47.578Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d4/09b92e1fcdccea9466bfae45455367ac52362ae445d96a602e51b7a8df73/msgpack-1.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ccfd880988f8438d1c91c77d7edc58e70f4d2012e999167bc154c64c6f06ea6b", size = 394603, upload-time = "2026-08-27T10:02:49.172Z" },
+    { url = "https://files.pythonhosted.org/packages/47/db/d11bd6f258a60703dcdc7a3772818ad0c2f602ee4c2acfb24088c6c3ebc3/msgpack-1.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:6195257a107bf25872ef84aab7295078271eea3ac6413f0506b631f6c9586ed5", size = 372666, upload-time = "2026-08-27T10:02:50.886Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/fbbbac0c6e5fbb9d51abc23e3b5fe8620f5c01e0588797cf664a623bb9e1/msgpack-1.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b8dd6c71d20c28d2d0eb0c51e7cccf3584afde3b1364f6629596186c9025bd54", size = 410889, upload-time = "2026-08-27T10:02:52.51Z" },
+    { url = "https://files.pythonhosted.org/packages/94/60/8366558da954095e04e7fbc351f9387d87a682feaee9a235ceda966f794b/msgpack-1.2.2-cp314-cp314-win32.whl", hash = "sha256:d242f3c4ccf55b056e6cf901720dccde58f1df117898f2bbf3bcd6e38ec7c248", size = 66774, upload-time = "2026-08-27T10:02:53.984Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/3d/1ce873c8057c65e4fbb076ffe1c99c9ae39d90a00a2540d7b06c652a292f/msgpack-1.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:1510f24612d4b983dff6935d9273e02c320cfd525727fbcb58836a75f589fdbc", size = 73424, upload-time = "2026-08-27T10:02:55.277Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/55/e36f2a33e38657f33850d74e0bf256838a0d45802c298cc501a32bffcc08/msgpack-1.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:7826f16edc763e768404f55605ef85dfcf5857e729c1ed29e0d7c180be4fe6d8", size = 67657, upload-time = "2026-08-27T10:02:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/64/58/7e764b957bae80ae281a9cb28761068c8bae8d5c6ac0873e43cc69d176c7/msgpack-1.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:f466049b8e1ec0854287bbe9a074316826fe0e08dcf707245f98b1ae49e92650", size = 86594, upload-time = "2026-08-27T10:02:57.796Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/f0/250f5985b6ee533e60d357571a808aaae03c54118294dc3db7158e27feb1/msgpack-1.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1f6b6f8deb07d49090e1808c6ef9cb7d23ca17bef3aa6ed3e5e03df16606e60c", size = 87374, upload-time = "2026-08-27T10:02:59.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2c/126ec8f187877c5f688631c543d1d3a3d75b2e66b83fb9de3ed7c13a39b6/msgpack-1.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b542ffc0a5c531eedc40419f291f1bd659aa8d4223408a5b51c88a2796083fd3", size = 428157, upload-time = "2026-08-27T10:03:00.9Z" },
+    { url = "https://files.pythonhosted.org/packages/95/21/d2d81d50aaedb14147d01f22094185794db3ad8a8791b60afacba0627c89/msgpack-1.2.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d095df2627e5dd59ac7b0c5ad627a671c76e6020171e03cbe4621a61f0562c3", size = 426669, upload-time = "2026-08-27T10:03:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/fc/f7d484ee5b572719608e7ffad569bea22ff11309a96ca2fae85eec94226b/msgpack-1.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ffdd2f4950daf7815490f23087963e3420175b9609520b7ff5df64d351159c22", size = 380625, upload-time = "2026-08-27T10:03:04.244Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/c4/b924cbd5516676f4e612329f18602a833bd055ffbe27f808eeba0f01bfea/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:652d1bf13d01bac8fd569def0fe76745e55bcda01e30aa6332d5947ea3788839", size = 411328, upload-time = "2026-08-27T10:03:05.869Z" },
+    { url = "https://files.pythonhosted.org/packages/27/9d/0c1d9683a951a80f270c3b7dac1022c18b9307617344dd44d904135d5e12/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:9bf452ff4d4981f25a18e9476e002bcc9263e7928024aa4d7148e25f7be3f929", size = 377892, upload-time = "2026-08-27T10:03:07.37Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bb/bf22338cdd22e0b40c8f28468cea5f3d9c320244c095d8303364bc012c41/msgpack-1.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:55faa6f8395e23b848c535ad5dcb96b3462f37f5e7f4ac500d500434f7345da7", size = 419426, upload-time = "2026-08-27T10:03:09Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/42/6d02c19a01abd8d7ce817c321d2ee6af1a8e24d584dca619d1b6576a83bf/msgpack-1.2.2-cp314-cp314t-win32.whl", hash = "sha256:419a45c67a5c04213172a14b1864657e014665b77d7081b107a51707923dd39e", size = 71810, upload-time = "2026-08-27T10:03:10.498Z" },
+    { url = "https://files.pythonhosted.org/packages/af/df/fda3a204415dab0a8c0db5461ef7205416ea52bd8581c5cafd361be07f3b/msgpack-1.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:935b1cfad9b908b0fa845010f4271df4c2f04e1cd26e3f18acd61a45f93c9e36", size = 78919, upload-time = "2026-08-27T10:03:12.016Z" },
+    { url = "https://files.pythonhosted.org/packages/63/d4/4b4b0ef25a86deca91feaf7252ca885ba4f2ada40461379120122a04fe96/msgpack-1.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11e8c421e117d1c36728b423d0402555cccbf0c6f53e288f0e75b6b12100d70f", size = 71925, upload-time = "2026-08-27T10:03:13.332Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/92/4b44bc8f3243ef8cf9cb5368c17a299d45b9df858f6dfdd98a0482dbbb37/msgpack-1.2.2-cp315-cp315-macosx_10_15_x86_64.whl", hash = "sha256:e1b99ad34613d5f8477fa5cf99bc4eaeaf27965588007c102370cd9a78fe9de5", size = 84293, upload-time = "2026-08-27T10:03:14.718Z" },
+    { url = "https://files.pythonhosted.org/packages/80/05/c992bb65744665a41b5bf531fc0e1619bae0901f57738228ded90023c151/msgpack-1.2.2-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:0fbc1bed8a535389b41882cfae66376e248cd1680eaa94fd83193c73e1d24986", size = 84490, upload-time = "2026-08-27T10:03:16.12Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/bf/7f53b9e6709a4df7f9b9b81dc65f9dfaa32caf65bee94986ec2cb8fa07f1/msgpack-1.2.2-cp315-cp315-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:06d95f61de7afe4f4ff908a6feebfcb070d0582ac87c9cf3cedf8551cf634516", size = 405332, upload-time = "2026-08-27T10:03:17.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/5a/305c4dca14b50d0b51fb88ef04ec125b8f0be3e2ce730dcc62dbaa651cc5/msgpack-1.2.2-cp315-cp315-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b5c696ae7cd7166b3657261adb855b461ff31f07823fdbae9de8bf80adfccc21", size = 416798, upload-time = "2026-08-27T10:03:19.389Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/df/a645102b4cdfd9a94201cac4e900e9c1429fc16d86aa311c06eef82528c9/msgpack-1.2.2-cp315-cp315-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0708afbf6a9587f0bfe479a9825c141d14d91e2f6a5c8103cf28bc96f4edb5d9", size = 377312, upload-time = "2026-08-27T10:03:20.928Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/26/c56d8d086d3fb1077bb48092b158b5ea2eee08b279e10c191275f13bc980/msgpack-1.2.2-cp315-cp315-musllinux_1_2_aarch64.whl", hash = "sha256:226a62ffe99fe54c5c61d910ec64c3449b7766c3280bd286bf6c94838dde239a", size = 395182, upload-time = "2026-08-27T10:03:22.571Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/b5/3d46ba367a565e536d8d2a61eebcee71b1dc803da3ce74a22313b573d6fa/msgpack-1.2.2-cp315-cp315-musllinux_1_2_riscv64.whl", hash = "sha256:9fd7f32e2f0fb334e7ecc5adb5cf0458785bd3a9d9d86f950e1715f101cebce5", size = 377945, upload-time = "2026-08-27T10:03:24.151Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/2c/d5d2df273ed5306357da25b69400fd8d7a53c4d87d8976604b677484d61c/msgpack-1.2.2-cp315-cp315-musllinux_1_2_x86_64.whl", hash = "sha256:9db1ba1c1e6a84245a9dd866265b56b8a1e9461549cc72ed296d8cbfbd32961b", size = 413341, upload-time = "2026-08-27T10:03:25.85Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fb/32613bced3cad47b40b1b73dd04d687121349d83f748efc2575929121903/msgpack-1.2.2-cp315-cp315-win32.whl", hash = "sha256:e2eb7ea0ac3911a7aac9d8aaa36d40f216d99455b3274cd3fac38181bcd910cf", size = 66730, upload-time = "2026-08-27T10:03:27.294Z" },
+    { url = "https://files.pythonhosted.org/packages/74/56/d86171f7251015e9312e5a7f9fdd4cf89752fc2114b88fed453d2a040c66/msgpack-1.2.2-cp315-cp315-win_amd64.whl", hash = "sha256:9352e6cdb510a7b1a5d3ccaccec730e82e50cf3484a3af7bdaab19e23b9589ff", size = 73477, upload-time = "2026-08-27T10:03:28.615Z" },
+    { url = "https://files.pythonhosted.org/packages/13/1a/56b90f6defef61700b86baca3637c15f62ac0f9b21ab0f16613ab9d1f101/msgpack-1.2.2-cp315-cp315-win_arm64.whl", hash = "sha256:29cc2d5291711a52956a79a51f41c732329df39ad727c886bd8f0b5b9237a808", size = 67660, upload-time = "2026-08-27T10:03:29.895Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/20/12751ca0d8ec874701b54c392c2b19f51af8dd1de40a92a10e356f0aaf58/msgpack-1.2.2-cp315-cp315t-macosx_10_15_x86_64.whl", hash = "sha256:d886baa46b2532135e7320067e6a44edb09ba5883a6096b0f9c044533984b8a8", size = 86462, upload-time = "2026-08-27T10:03:31.348Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4c/cf6d12a3d709fe5f9771dd917c35e6ebcd55597a5b792287382fde056c95/msgpack-1.2.2-cp315-cp315t-macosx_11_0_arm64.whl", hash = "sha256:53679573c75cce5f82359e0bd4e6a97809a6b9a9b7a48fd1ba592f4a82cddc84", size = 87412, upload-time = "2026-08-27T10:03:32.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/0d/0aac5752d1708dcb458f8754db34a4999514db3df2d2b798b9381293f638/msgpack-1.2.2-cp315-cp315t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d3c247d457ae9079974c7ce3c665396754a6d2baff7eaa51332212a8a5a3f13b", size = 422057, upload-time = "2026-08-27T10:03:34.124Z" },
+    { url = "https://files.pythonhosted.org/packages/81/30/70f281a3685b04aaf235a5237da11b978a02a865a5a479186205177ad676/msgpack-1.2.2-cp315-cp315t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:352ed831042549cca8be23780e1fe7c9177e65ff02bf183509c4b4d33f671782", size = 422696, upload-time = "2026-08-27T10:03:35.862Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/6d/f76e8425efb0aa38988cd778ae290bfa120491d80d26872d88bb52fedb3f/msgpack-1.2.2-cp315-cp315t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f80361592c13d7226b4379c8941529b63fe1a9d0e05d2de8f3306b70e522b53f", size = 376495, upload-time = "2026-08-27T10:03:37.339Z" },
+    { url = "https://files.pythonhosted.org/packages/95/77/0809aa9b52b2868f7d01862dc14073708f0440421a65197b48453480034c/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_aarch64.whl", hash = "sha256:68df2947921d449f6dcfeafd86cb2cdde13327a8b447534bbe4ee5aaf32a5695", size = 404683, upload-time = "2026-08-27T10:03:38.87Z" },
+    { url = "https://files.pythonhosted.org/packages/02/d2/4e5ac915ba120172d210ef00165c5e6276c8a65db3a4a5cf36e946b83e23/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_riscv64.whl", hash = "sha256:51dd39d23cfdea0400ed3ff2d29d1e83bd951d3aea79dc89be5b701a09edfe23", size = 375087, upload-time = "2026-08-27T10:03:40.486Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e3/8051d53e5495c87c6cf27eb42fb680361017037f87f322bdaf525f71e4a2/msgpack-1.2.2-cp315-cp315t-musllinux_1_2_x86_64.whl", hash = "sha256:b13b59e66f107cca1ba708dd5307179870ca1b15b19fcee7ccf722e5308d9212", size = 414421, upload-time = "2026-08-27T10:03:42.308Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/4e/13783aa7c17414d7186c72c49bc718366f75e49f0ea58d4f81cb63ac3187/msgpack-1.2.2-cp315-cp315t-win32.whl", hash = "sha256:8c6321a414f8b4a8dc43976b2fa8349156434ca9adedd9a187b796f7e1d3d3fc", size = 71790, upload-time = "2026-08-27T10:03:43.715Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/9d/1d02994c7ae2603c98100984428ff0f67443572133bc18eca6058f732c1b/msgpack-1.2.2-cp315-cp315t-win_amd64.whl", hash = "sha256:6f53285f20d592ed309ee19e509cc4c77a3bda1db02ad67e8a0949bb227a5a6d", size = 78766, upload-time = "2026-08-27T10:03:45.036Z" },
+    { url = "https://files.pythonhosted.org/packages/60/54/89ed16e6f966a050dc78b0e94a545025211b07ce9f4bdfe07dff70c03fc2/msgpack-1.2.2-cp315-cp315t-win_arm64.whl", hash = "sha256:a378e12ccc06d76efde115caf4073b7e5ff3cc18291d1341f9e65fb882e3f754", size = 71819, upload-time = "2026-08-27T10:03:46.375Z" },
+]
+
+[[package]]
 name = "numpy"
 version = "2.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -666,6 +939,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/42/06/6e11443f7b64ee376c860506091103bf68f92d2cab9e8d96d4501babf07c/numpy-2.5.2-cp315-cp315t-win32.whl", hash = "sha256:7354826bc6f8f69402e9b7fe28d15fcd34feebd74f856f111585c5b0c9fb0251", size = 6269775, upload-time = "2026-08-09T13:48:17.543Z" },
     { url = "https://files.pythonhosted.org/packages/f1/18/195d6b86cd72dbbc501edfa778005fa6b87afd34c153e46028cd3a0938f4/numpy-2.5.2-cp315-cp315t-win_amd64.whl", hash = "sha256:e5651f3f87add730ee6608d915009e19c911fba0cb000c7e3ea994b7d768eb12", size = 12782559, upload-time = "2026-08-09T13:48:21.023Z" },
     { url = "https://files.pythonhosted.org/packages/b4/07/458c344f0f0c178f4481dad5cca790626ffe4c34eabf9467069d06ee4999/numpy-2.5.2-cp315-cp315t-win_arm64.whl", hash = "sha256:5f8e00be2ec6f45f4e8a41a527f68d44a7d96fee92a650e4d8b1326f77f61e6e", size = 10748103, upload-time = "2026-08-09T13:48:24.21Z" },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.44.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ee/8b/aa9e2d8b8dfa7c946f7dec5d1f8f6ba8eca062f43509a06bdb5ce93d26c0/opentelemetry_api-1.44.0.tar.gz", hash = "sha256:67647e5e9566edcf421166fdf022b3537f818635daa852b289e34604dc6fb33a", size = 72406, upload-time = "2026-07-16T15:25:32.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/6f/a04e900f465ff3221ccc395522503e2d10e79fa21f2723c8e177aae1e0d1/opentelemetry_api-1.44.0-py3-none-any.whl", hash = "sha256:94b98c893a91b88657eaac1e3ba89618cdb85be6918196705354f34728b2cdef", size = 60018, upload-time = "2026-07-16T15:25:11.657Z" },
 ]
 
 [[package]]
@@ -775,6 +1060,33 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/a6/4fbadcc2044034449b3f8f0ce82dcf3005d53f37c136642103fd4836a31c/proto_plus-1.28.4.tar.gz", hash = "sha256:5ff7ecad828e032a491fcb86947801768e32237f99dd049b649965b892ae9a63", size = 58679, upload-time = "2026-08-25T19:19:15.102Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/5d/0f04b85dafdc3250ced7f2592efc17dce7f40712e941e9632202481e600d/proto_plus-1.28.4-py3-none-any.whl", hash = "sha256:4b01341272f8a348db3f003b6143109f83ab43091019d5181b3fcdf500ab32aa", size = 50797, upload-time = "2026-08-25T19:18:12.338Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "7.36.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/73/f66c748df06e7fe24e658eddd600d19c4b40bad836c97ce2d0ad9851fb6b/protobuf-7.36.1.tar.gz", hash = "sha256:d0f6470f0ce2b84e3feaea2d4b816378b37ba4d4aa08a274305373de93e2d524", size = 512499, upload-time = "2026-08-31T22:40:04.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/6c/3a54a58f2948b0f485df9ecdd06590f15d0a7abf46a89d50c3de709ff4ff/protobuf-7.36.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:3cf2ee25d006cee57294a1196ea43b37feb78e0dcd1e8af5c1aeddb777655aca", size = 456046, upload-time = "2026-08-31T22:39:56.865Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/08/9f9548793c771095245c0eeaf0c84b76b16a5ef26158043d456f551344a0/protobuf-7.36.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:43d3d37b1eb24c113b9b7d02008cac44e423f00b611b7781ae998d7623972969", size = 344226, upload-time = "2026-08-31T22:39:58.263Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/51/1bdbd612fa3c51e42ea6f45d05e84dc748ddcd2663e1aa1e89a00a33facd/protobuf-7.36.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:39c518c05586c016d7874ff6079ee115bcec1ea5fbb1d177fbf7867ef4c67e44", size = 357229, upload-time = "2026-08-31T22:39:59.198Z" },
+    { url = "https://files.pythonhosted.org/packages/22/df/c799fe7a05ef16ba853a59db01f3a2c5f7d0676469589ccc4874f76a2a88/protobuf-7.36.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:97198b77e369a0abd8e262b8f6c7266c55ddb796a3a12c76d7b8881188ed83aa", size = 343228, upload-time = "2026-08-31T22:40:00.179Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/33/d4724ec5d86d496fe4108e220618aa0837ad3423a7af7ccdd9684ccc77c8/protobuf-7.36.1-cp310-abi3-win32.whl", hash = "sha256:0b53ce95272aad50ad25d7ff03373743209822e8ba42ea7fad27d2bee1547d00", size = 443002, upload-time = "2026-08-31T22:40:01.32Z" },
+    { url = "https://files.pythonhosted.org/packages/db/37/155788a0d8daded960375af604202805308169f9b859419ea0aa370946e2/protobuf-7.36.1-cp310-abi3-win_amd64.whl", hash = "sha256:51139351435d9b43d88a55eaa49fb6f737fbb478fb0cbf2cf694d1a04a9d3363", size = 456518, upload-time = "2026-08-31T22:40:02.494Z" },
+    { url = "https://files.pythonhosted.org/packages/39/ca/c47f91d3cab175b01fd8c4f0d80fdf8613be876cc616e66ad281a59c5ddf/protobuf-7.36.1-py3-none-any.whl", hash = "sha256:7d951e46b3f963d6c264c367c437921de9d5aedd9c3f9612b9077736b4e3ad5c", size = 179813, upload-time = "2026-08-31T22:40:03.54Z" },
+]
+
+[[package]]
 name = "psycopg2-binary"
 version = "2.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -791,6 +1103,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/ad/44b06659949b243ae10112cd3b20a197f9bf3e81d5651379b9eb889bfaad/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:77b348775efd4cdab410ec6609d81ccecd1139c90265fa583a7255c8064bc03d", size = 3048977, upload-time = "2026-04-20T23:35:41.806Z" },
     { url = "https://files.pythonhosted.org/packages/1d/f2/10a1bcebadb6aa55e280e1f58975c36a7b560ea525184c7aa4064c466633/psycopg2_binary-2.9.12-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:527e6342b3e44c2f0544f6b8e927d60de7f163f5723b8f1dfa7d2a84298738cd", size = 3351466, upload-time = "2026-04-20T23:35:43.993Z" },
     { url = "https://files.pythonhosted.org/packages/20/be/b732c8418ffa5bcfda002890f5dc4c869fc17db66ff11f53b17cfe44afc0/psycopg2_binary-2.9.12-cp314-cp314-win_amd64.whl", hash = "sha256:f12ae41fcafadb39b2785e64a40f9db05d6de2ac114077457e0e7c597f3af980", size = 2848762, upload-time = "2026-04-20T23:35:46.421Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -888,6 +1221,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1052,6 +1390,7 @@ dependencies = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "fastapi-limiter" },
+    { name = "firebase-admin" },
     { name = "gunicorn" },
     { name = "httpx" },
     { name = "jinja2" },
@@ -1097,6 +1436,7 @@ requires-dist = [
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "fastapi-limiter" },
+    { name = "firebase-admin", specifier = ">=7.5.0" },
     { name = "gunicorn", specifier = ">=25,<26" },
     { name = "httpx" },
     { name = "jinja2" },


### PR DESCRIPTION
## Summary

Adds `PushService.notify(end_user_id, category, title, body, data)`: creates a `Notification` row, fans it out to every active `Device` for that End user via a `PushGatewayPort`, records one `NotificationDelivery` per device (success/failed), and deactivates any device Firebase Cloud Messaging reports as unregistered. Backed by a real `firebase-admin` implementation (ADR-0007), initialized once as a guarded DI singleton so a missing `FIREBASE_CREDENTIALS_JSON` doesn't break the app or the existing device-registration endpoint — it only fails when a push is actually attempted.

No trigger is wired up in this PR — this is the reusable capability only, per the originating ticket.

Closes #29

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- `PushGatewayPort.send_multicast` batches at FCM's 500-token multicast limit; a batch-level exception is caught per-batch so a failure in a later batch can't discard already-successful earlier batches' results.
- Any exception from the gateway is caught in `PushService.notify` and recorded as failed `NotificationDelivery` rows — `notify()` never raises to its caller.
- Zero active devices for an End user is a no-op (the `Notification` row is still created).
- New dependency: `firebase-admin` (added via `uv add`).

## Testing

- [x] `uv run pytest` — 100 passed
- [x] `uv run ruff format` / `uv run ruff check --fix` — clean

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge