### PR TITLE
refactor(push): load Firebase credentials per-environment

### DIFF
--- a/example.env
+++ b/example.env
@@ -37,8 +37,9 @@ MAGIC_LINK_TOKEN_EXPIRE_MINUTES=15
 # Admin Google ID-token sign-in (ADR 0006) — comma-separated Client ID allowlist; empty disables Google admin sign-in
 GOOGLE_ADMIN_CLIENT_IDS=
 
-# Push notifications (ADR 0007) — Firebase service-account JSON, not a file path; empty disables push send
-FIREBASE_CREDENTIALS_JSON=
+# Push notifications (ADR 0007) — Firebase service-account credential, loaded per environment:
+# 1) FIREBASE_CREDENTIALS_PATH (if set) 2) env/firebase_credentials.json 3) /etc/secrets/firebase_credentials.json
+FIREBASE_CREDENTIALS_PATH=
 
 # Logging
 SENSITIVE_PARAMS=password,token,secret

--- a/portal/config.py
+++ b/portal/config.py
@@ -2,6 +2,7 @@
 Configuration
 """
 
+import json
 import logging
 import os
 from functools import lru_cache
@@ -133,14 +134,53 @@ class Configuration(BaseSettings):
     # [Rate Limiting]
     RATE_LIMITERS_CONFIG: RateLimitersConfig | None = None
 
-    # [Push notifications — Firebase Cloud Messaging, ADR 0007. Service-account JSON, not a file path.]
-    FIREBASE_CREDENTIALS_JSON: str | None = os.getenv(key="FIREBASE_CREDENTIALS_JSON")
+    # [Push notifications — Firebase Cloud Messaging, ADR 0007. Service-account credential, loaded per environment; see _load_firebase_credentials.]
+    FIREBASE_CREDENTIALS_PATH: str | None = os.getenv(key="FIREBASE_CREDENTIALS_PATH")
+    FIREBASE_CREDENTIALS: dict = {}
 
     # [Sentry]
     SENTRY_URL: str | None = os.getenv(key="SENTRY_URL")
 
     # [Logging]
     SENSITIVE_PARAMS: set[str] = set(os.getenv(key="SENSITIVE_PARAMS", default="password,secret,api_key").split(","))
+
+    @model_validator(mode="after")
+    def _load_firebase_credentials(self) -> "Configuration":
+        """
+        Load the Firebase service-account credential from, in order:
+        1) FIREBASE_CREDENTIALS_PATH env var (if provided)
+        2) env/firebase_credentials.json
+        3) /etc/secrets/firebase_credentials.json
+        """
+        if self.FIREBASE_CREDENTIALS:
+            return self
+
+        candidate_paths: list[str] = []
+        if self.FIREBASE_CREDENTIALS_PATH:
+            candidate_paths.append(self.FIREBASE_CREDENTIALS_PATH)
+
+        project_dir = Path(__file__).resolve().parent.parent
+        candidate_paths.extend([os.path.join(project_dir, "env/firebase_credentials.json"), "/etc/secrets/firebase_credentials.json"])
+
+        for candidate_path in candidate_paths:
+            try:
+                firebase_credentials_path: Path = Path(candidate_path)
+                if firebase_credentials_path.exists():
+                    self.FIREBASE_CREDENTIALS = json.loads(firebase_credentials_path.read_text())
+                    logger = logging.getLogger(self.APP_NAME)
+                    logger.info(f"Firebase credentials loaded from {candidate_path}")
+                    break
+            except FileNotFoundError:
+                continue
+            except Exception as exc:
+                logger = logging.getLogger(self.APP_NAME)
+                logger.warning(f"Failed to load Firebase credentials from {candidate_path}: {exc}")
+
+        if not self.FIREBASE_CREDENTIALS:
+            logger = logging.getLogger(self.APP_NAME)
+            logger.warning("Firebase credentials not found; push notifications will fail until configured")
+
+        return self
 
     @model_validator(mode="after")
     def _load_rate_limiters_config(self) -> "Configuration":

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -34,4 +34,4 @@ class CoreContainer(containers.DeclarativeContainer):
     password_provider = providers.Singleton(PasswordProvider)
     refresh_token_provider = providers.Factory(RefreshTokenProvider, session=request_session)
     google_id_token_verifier = providers.Singleton(GoogleIdTokenVerifier)
-    push_gateway = providers.Singleton(FirebasePushGateway, credentials_json=config.FIREBASE_CREDENTIALS_JSON)
+    push_gateway = providers.Singleton(FirebasePushGateway, credentials_dict=config.FIREBASE_CREDENTIALS)

--- a/portal/providers/firebase_push_gateway.py
+++ b/portal/providers/firebase_push_gateway.py
@@ -3,7 +3,6 @@ Firebase Cloud Messaging push gateway (ADR 0007 — direct FCM integration).
 """
 
 import asyncio
-import json
 from typing import Optional
 
 import firebase_admin
@@ -25,20 +24,19 @@ class FirebasePushGateway:
     default app, which would otherwise blow up on every DI construction).
     """
 
-    def __init__(self, credentials_json: Optional[str]):
+    def __init__(self, credentials_dict: Optional[dict]):
         self._app = None
         try:
             self._app = firebase_admin.get_app()
         except ValueError:
-            if not credentials_json:
-                logger.warning("FIREBASE_CREDENTIALS_JSON is not set; push notifications will fail until it is configured")
+            if not credentials_dict:
+                logger.warning("Firebase credentials are not configured; push notifications will fail until they are")
                 return
-            certificate = credentials.Certificate(json.loads(credentials_json))
-            self._app = firebase_admin.initialize_app(certificate)
+            self._app = firebase_admin.initialize_app(credentials.Certificate(credentials_dict))
 
     async def send_multicast(self, *, tokens: list[str], title: str, body: str, data: Optional[dict]) -> list[PushSendResult]:
         if self._app is None:
-            raise RuntimeError("Firebase push gateway is not configured (missing FIREBASE_CREDENTIALS_JSON)")
+            raise RuntimeError("Firebase push gateway is not configured (missing Firebase credentials)")
 
         string_data = {key: str(value) for key, value in (data or {}).items()}
         results: list[PushSendResult] = []


### PR DESCRIPTION
## Summary

Follow-up to #29 / #31. Replaces `FIREBASE_CREDENTIALS_JSON` (a raw service-account JSON blob in a single env var) with a per-environment file-based loader, matching the pattern already used for `RATE_LIMITERS_CONFIG` in this repo (and Google/Firebase credential loading in `conf-portal-api`):

1. `FIREBASE_CREDENTIALS_PATH` env var (if set)
2. `env/firebase_credentials.json`
3. `/etc/secrets/firebase_credentials.json`

This avoids the quoting/newline pain of putting a multi-line service-account JSON into a single `.env` value, and lets each environment (local dev, staging, prod) mount its own credential file at a fixed path instead.

`FirebasePushGateway` now takes the parsed credential dict directly instead of a JSON string.

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [x] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Mirrors `Configuration._load_rate_limiters_config`'s candidate-path loading pattern.
- No behavior change to `PushService.notify()` or the gateway's send logic — only how the credential is sourced.

## Testing

- [x] `uv run pytest` — 100 passed (verified in a clean worktree off `origin/main`)
- [x] `uv run ruff format` / `uv run ruff check` on changed files — clean
- [x] Manually verified `FIREBASE_CREDENTIALS_PATH` pointing at a real service-account file loads and initializes the Firebase app

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge