### PR TITLE
feat(auth): add Google sign-in for End users

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,7 +208,7 @@ See ADR 0003.
 
 - **Passwordless:** email-OTP request/verify for End users (ADR 0008). Auth credentials may have `password_hash` null.
 - Shared JWT access/refresh infrastructure with Admin; product FKs hang off End user (`app.user`), not `auth.user` alone (ADR 0004).
-- Identity provider catalog + Identity link rows (ADR 0005). **Admin Google** ID-token HTTP is ADR 0006. End-user Apple/Google HTTP remains a future ADR.
+- Identity provider catalog + Identity link rows (ADR 0005). **Admin Google** ID-token HTTP is ADR 0006; **End-user Google** ID-token HTTP is ADR 0008 (the End-user flow may provision on first success; the Admin one never does).
 - **Excluded:** Microsoft Entra ID token exchange, Admin Apple, app password register/login as the product path, phone-as-login-id.
 
 ### Admin

--- a/example.env
+++ b/example.env
@@ -39,6 +39,9 @@ OTP_REQUEST_WINDOW_SECONDS=600
 # Admin Google ID-token sign-in (ADR 0006) — comma-separated Client ID allowlist; empty disables Google admin sign-in
 GOOGLE_ADMIN_CLIENT_IDS=
 
+# End-user Google ID-token sign-in (ADR 0008) — comma-separated Client ID allowlist; empty disables Google app sign-in
+GOOGLE_APP_CLIENT_IDS=
+
 # Push notifications (ADR 0007) — Firebase service-account credential, loaded per environment:
 # 1) FIREBASE_CREDENTIALS_PATH (if set) 2) env/firebase_credentials.json 3) /etc/secrets/firebase_credentials.json
 FIREBASE_CREDENTIALS_PATH=

--- a/portal/application/auth/app_auth_service.py
+++ b/portal/application/auth/app_auth_service.py
@@ -4,27 +4,18 @@ App (End user) passwordless email-OTP auth use cases (ADR 0008).
 
 import hashlib
 import secrets
-from datetime import datetime, timezone
-from typing import Optional
-from uuid import UUID, uuid4
 
 from portal.application.app.commands import ProvisionIdentityCommand
 from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
 from portal.application.auth.commands import AppOtpRequestCommand, AppOtpVerifyCommand
-from portal.application.auth.mappers import normalize_user_for_token
-from portal.application.auth.member_web_app_resolver import resolve_request_app_code
-from portal.application.auth.results import MemberLoginResult, MemberProfileResult, OtpRequestResult, TokenResult, UserSensitive
+from portal.application.auth.member_login_service import MemberLoginService
+from portal.application.auth.results import MemberLoginResult, OtpRequestResult
 from portal.config import settings
-from portal.domain.app.ports import EndUserRepositoryPort, PreferencesRepositoryPort
-from portal.domain.auth.member_web_app import MemberWebAppRegistry
+from portal.domain.app.ports import EndUserRepositoryPort
 from portal.domain.auth.ports import OtpMailerPort, OtpTokenPort, UserRepositoryPort
 from portal.exceptions.responses import TooManyRequestsException, UnauthorizedException
-from portal.libs.consts.enums import AccessTokenAudType
 from portal.libs.contexts.request_context import get_resolved_locale_code
 from portal.libs.tracing.distributed_trace import distributed_trace
-from portal.providers.jwt_provider import JWTProvider
-from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
-from portal.providers.refresh_token_provider import RefreshTokenProvider
 
 _OTP_ACK_MESSAGE = "If the email is valid, a passcode has been sent"
 _OTP_FAILURE_DETAIL = "Invalid or expired passcode"
@@ -45,29 +36,16 @@ class AppAuthService:
         provisioning_service: EndUserProvisioningService,
         user_repository: UserRepositoryPort,
         end_user_repository: EndUserRepositoryPort,
-        preferences_repository: PreferencesRepositoryPort,
         otp_token_store: OtpTokenPort,
         otp_mailer: OtpMailerPort,
-        jwt_provider: JWTProvider,
-        refresh_token_provider: RefreshTokenProvider,
-        member_refresh_app_binding_provider: Optional[MemberRefreshAppBindingProvider],
-        member_web_app_registry: MemberWebAppRegistry,
+        member_login_service: MemberLoginService,
     ):
         self._provisioning_service = provisioning_service
         self._user_repository = user_repository
         self._end_user_repository = end_user_repository
-        self._preferences_repository = preferences_repository
         self._otp_token_store = otp_token_store
         self._otp_mailer = otp_mailer
-        self._jwt_provider = jwt_provider
-        self._refresh_token_provider = refresh_token_provider
-        self._member_refresh_app_binding_provider = member_refresh_app_binding_provider
-        self._member_web_app_registry = member_web_app_registry
-
-    def _resolve_app_code(self) -> str:
-        app_code = resolve_request_app_code(self._member_web_app_registry, required=True)
-        assert app_code is not None
-        return app_code
+        self._member_login_service = member_login_service
 
     @staticmethod
     def _generate_code() -> str:
@@ -103,7 +81,7 @@ class AppAuthService:
         End user + Preferences on first use. Every rejection path raises the same generic
         failure — no account enumeration.
         """
-        app_code = self._resolve_app_code()
+        app_code = self._member_login_service.resolve_app_code()
         email = command.email.strip().lower()
         if not await self._otp_token_store.consume(email, self._hash_code(email, command.code)):
             raise UnauthorizedException(detail=_OTP_FAILURE_DETAIL)
@@ -125,35 +103,4 @@ class AppAuthService:
                 raise UnauthorizedException(detail=_OTP_FAILURE_DETAIL)
             end_user_id = end_user.id
 
-        preferences = await self._preferences_repository.get_by_user_id(end_user_id)
-        preferred_name = preferences.display_name if preferences else None
-        return await self._issue_member_tokens(user=user, app_code=app_code, end_user_id=end_user_id, preferred_name=preferred_name)
-
-    async def _issue_member_tokens(self, *, user: UserSensitive, app_code: str, end_user_id: UUID, preferred_name: Optional[str]) -> MemberLoginResult:
-        token_user = normalize_user_for_token(user)
-        if preferred_name:
-            token_user = token_user.model_copy(update={"preferred_name": preferred_name, "first_name": preferred_name})
-
-        family_id = uuid4()
-        device_id = uuid4()
-        access_token = self._jwt_provider.create_access_token(user=token_user, family_id=family_id, aud_type=AccessTokenAudType.USER, azp=app_code)
-        refresh_token = await self._refresh_token_provider.issue(user_id=user.id, device_id=device_id, family_id=family_id)
-        if self._member_refresh_app_binding_provider:
-            await self._member_refresh_app_binding_provider.bind(family_id, app_code)
-
-        now = datetime.now(timezone.utc)
-        await self._user_repository.update_last_login_at(user_id=user.id, last_login_at=now)
-
-        expires_in = settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
-        token = TokenResult(access_token=access_token, refresh_token=refresh_token, token_type="bearer", expires_in=expires_in)
-        member = MemberProfileResult(
-            id=end_user_id,
-            email=user.email or "",
-            first_name=preferred_name or "",
-            last_name="",
-            preferred_name=preferred_name,
-            roles=[],
-            preferred_locale_id=user.preferred_locale_id,
-            last_login_at=user.last_login_at,
-        )
-        return MemberLoginResult(member=member, token=token)
+        return await self._member_login_service.complete_member_login(user=user, end_user_id=end_user_id, app_code=app_code)

--- a/portal/application/auth/app_google_auth_service.py
+++ b/portal/application/auth/app_google_auth_service.py
@@ -1,0 +1,102 @@
+"""
+End-user Google ID-token sign-in application service (ADR 0008).
+
+Parallel to AdminGoogleAuthService, with one deliberate difference: a first
+success that matches nothing may create the Auth credential + End user +
+Preferences, whereas the Admin flow only ever binds to an existing credential.
+"""
+
+from portal.application.app.commands import ProvisionIdentityCommand
+from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.commands import AppGoogleLoginCommand
+from portal.application.auth.member_login_service import MemberLoginService
+from portal.application.auth.results import MemberLoginResult, UserSensitive
+from portal.config import settings
+from portal.domain.app.ports import EndUserRepositoryPort
+from portal.domain.auth.entities import GoogleIdentityClaims
+from portal.domain.auth.ports import GoogleIdTokenVerifierPort, UserRepositoryPort
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+GOOGLE_PROVIDER_CODE = "google"
+GENERIC_FAILURE_DETAIL = "Google sign-in failed"
+
+
+def _is_end_user_eligible(user: UserSensitive) -> bool:
+    return user.verified and user.is_active
+
+
+class AppGoogleAuthService:
+    """Resolve a verified Google ID token to an End user, provisioning one on first success."""
+
+    def __init__(
+        self,
+        provisioning_service: EndUserProvisioningService,
+        user_repository: UserRepositoryPort,
+        end_user_repository: EndUserRepositoryPort,
+        google_id_token_verifier: GoogleIdTokenVerifierPort,
+        member_login_service: MemberLoginService,
+    ):
+        self._provisioning_service = provisioning_service
+        self._user_repository = user_repository
+        self._end_user_repository = end_user_repository
+        self._verifier = google_id_token_verifier
+        self._member_login_service = member_login_service
+
+    @distributed_trace()
+    async def login_with_google(self, command: AppGoogleLoginCommand) -> MemberLoginResult:
+        """
+        Resolution order: existing Identity link by `sub`, else verified email
+        (case-insensitive) match to an existing End user's Auth credential, else
+        provision a brand-new credential + End user + Preferences. Every rejection
+        path raises the same generic failure — no account enumeration.
+        """
+        app_code = self._member_login_service.resolve_app_code()
+
+        client_ids = settings.google_app_client_ids
+        if not client_ids or not await self._user_repository.identity_provider_is_active(GOOGLE_PROVIDER_CODE):
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        claims = await self._verifier.verify(command.id_token, audiences=client_ids)
+        if not claims or not claims.email_verified or not claims.email:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        linked_user_id = await self._user_repository.get_user_id_by_identity_link(GOOGLE_PROVIDER_CODE, claims.subject)
+        if linked_user_id:
+            user = await self._user_repository.get_sensitive_by_id(linked_user_id)
+            if not user or not _is_end_user_eligible(user):
+                raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+            end_user = await self._end_user_repository.get_by_auth_user_id(user.id)
+            if not end_user:
+                raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+            return await self._member_login_service.complete_member_login(user=user, end_user_id=end_user.id, app_code=app_code)
+
+        email = claims.email.strip().lower()
+        # An End user credential has no AuthUserProfile row, so the profile-joining
+        # lookup the Admin flow uses would never match one.
+        user = await self._user_repository.get_sensitive_by_email_without_profile(email)
+        if user is None:
+            return await self._provision_and_login(claims=claims, email=email, app_code=app_code)
+
+        if not _is_end_user_eligible(user):
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+        # An admin-only credential has no End user row; refuse it here exactly as OTP verify does,
+        # rather than silently attaching product identity to a console account.
+        end_user = await self._end_user_repository.get_by_auth_user_id(user.id)
+        if not end_user:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        await self._user_repository.upsert_identity_link(user.id, GOOGLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})
+        return await self._member_login_service.complete_member_login(user=user, end_user_id=end_user.id, app_code=app_code)
+
+    async def _provision_and_login(self, *, claims: GoogleIdentityClaims, email: str, app_code: str) -> MemberLoginResult:
+        provisioned = await self._provisioning_service.provision(ProvisionIdentityCommand(email=email, password=None, create_end_user=True))
+        if provisioned.end_user_id is None:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        user = await self._user_repository.get_sensitive_by_email_without_profile(email)
+        if not user:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        await self._user_repository.upsert_identity_link(user.id, GOOGLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})
+        return await self._member_login_service.complete_member_login(user=user, end_user_id=provisioned.end_user_id, app_code=app_code)

--- a/portal/application/auth/commands.py
+++ b/portal/application/auth/commands.py
@@ -51,6 +51,12 @@ class AdminGoogleLoginCommand(BaseModel):
     id_token: str = Field(..., description="Google ID token from Google Identity Services")
 
 
+class AppGoogleLoginCommand(BaseModel):
+    """End-user Google ID-token sign-in command (ADR 0008)."""
+
+    id_token: str = Field(..., description="Google ID token from the app's Google sign-in client")
+
+
 class LogoutCommand(BaseModel):
     """Logout command."""
 

--- a/portal/application/auth/member_login_service.py
+++ b/portal/application/auth/member_login_service.py
@@ -1,0 +1,85 @@
+"""
+Shared member (End user) login completion — issue JWTs and build the member profile.
+
+Mirrors LoginService.complete_admin_login for the app side: every End-user sign-in
+path (email OTP, Google, …) funnels through here so token issuance stays in one place.
+"""
+
+from datetime import datetime, timezone
+from typing import Optional
+from uuid import UUID, uuid4
+
+from portal.application.auth.mappers import normalize_user_for_token
+from portal.application.auth.member_web_app_resolver import resolve_request_app_code
+from portal.application.auth.results import MemberLoginResult, MemberProfileResult, TokenResult, UserSensitive
+from portal.config import settings
+from portal.domain.app.ports import PreferencesRepositoryPort
+from portal.domain.auth.member_web_app import MemberWebAppRegistry
+from portal.domain.auth.ports import UserRepositoryPort
+from portal.libs.consts.enums import AccessTokenAudType
+from portal.libs.tracing.distributed_trace import distributed_trace
+from portal.providers.jwt_provider import JWTProvider
+from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
+from portal.providers.refresh_token_provider import RefreshTokenProvider
+
+
+class MemberLoginService:
+    """Issue member tokens for an already-resolved End user."""
+
+    def __init__(
+        self,
+        user_repository: UserRepositoryPort,
+        preferences_repository: PreferencesRepositoryPort,
+        jwt_provider: JWTProvider,
+        refresh_token_provider: RefreshTokenProvider,
+        member_refresh_app_binding_provider: Optional[MemberRefreshAppBindingProvider],
+        member_web_app_registry: MemberWebAppRegistry,
+    ):
+        self._user_repository = user_repository
+        self._preferences_repository = preferences_repository
+        self._jwt_provider = jwt_provider
+        self._refresh_token_provider = refresh_token_provider
+        self._member_refresh_app_binding_provider = member_refresh_app_binding_provider
+        self._member_web_app_registry = member_web_app_registry
+
+    def resolve_app_code(self) -> str:
+        """Resolve the calling member web app from the request, raising when it is not allowed."""
+        app_code = resolve_request_app_code(self._member_web_app_registry, required=True)
+        assert app_code is not None
+        return app_code
+
+    @distributed_trace()
+    async def complete_member_login(self, *, user: UserSensitive, end_user_id: UUID, app_code: str) -> MemberLoginResult:
+        """
+        Issue an access/refresh pair bound to the calling app and return the member
+        profile. The profile id is app.user.id (End user), never auth.user.id.
+        """
+        preferences = await self._preferences_repository.get_by_user_id(end_user_id)
+        preferred_name = preferences.display_name if preferences else None
+
+        token_user = normalize_user_for_token(user)
+        if preferred_name:
+            token_user = token_user.model_copy(update={"preferred_name": preferred_name, "first_name": preferred_name})
+
+        family_id = uuid4()
+        device_id = uuid4()
+        access_token = self._jwt_provider.create_access_token(user=token_user, family_id=family_id, aud_type=AccessTokenAudType.USER, azp=app_code)
+        refresh_token = await self._refresh_token_provider.issue(user_id=user.id, device_id=device_id, family_id=family_id)
+        if self._member_refresh_app_binding_provider:
+            await self._member_refresh_app_binding_provider.bind(family_id, app_code)
+
+        await self._user_repository.update_last_login_at(user_id=user.id, last_login_at=datetime.now(timezone.utc))
+
+        expires_in = settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
+        token = TokenResult(access_token=access_token, refresh_token=refresh_token, token_type="bearer", expires_in=expires_in)
+        member = MemberProfileResult(
+            id=end_user_id,
+            email=user.email or "",
+            first_name=preferred_name or "",
+            last_name="",
+            preferred_name=preferred_name,
+            roles=[],
+            preferred_locale_id=user.preferred_locale_id,
+            last_login_at=user.last_login_at,
+        )
+        return MemberLoginResult(member=member, token=token)

--- a/portal/config.py
+++ b/portal/config.py
@@ -126,6 +126,9 @@ class Configuration(BaseSettings):
     # [Admin Google ID-token sign-in — ADR 0006. Comma-separated Client ID allowlist; empty disables Google admin sign-in.]
     GOOGLE_ADMIN_CLIENT_IDS: str = os.getenv(key="GOOGLE_ADMIN_CLIENT_IDS", default="")
 
+    # [End-user Google ID-token sign-in — ADR 0008. Comma-separated Client ID allowlist; empty disables Google app sign-in.]
+    GOOGLE_APP_CLIENT_IDS: str = os.getenv(key="GOOGLE_APP_CLIENT_IDS", default="")
+
     # [Member web apps — Origin -> app_code for /api/v1 auth]
     MEMBER_WEB_APPS: str = os.getenv(key="MEMBER_WEB_APPS", default="rooted-app|http://localhost:5174")
 
@@ -241,6 +244,10 @@ class Configuration(BaseSettings):
     @property
     def google_admin_client_ids(self) -> list[str]:
         return [client_id.strip() for client_id in self.GOOGLE_ADMIN_CLIENT_IDS.split(",") if client_id.strip()]
+
+    @property
+    def google_app_client_ids(self) -> list[str]:
+        return [client_id.strip() for client_id in self.GOOGLE_APP_CLIENT_IDS.split(",") if client_id.strip()]
 
 
 @lru_cache

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -54,6 +54,7 @@ class RootContainer(containers.DeclarativeContainer):
     bible_service = app.bible_service
     end_user_provisioning_service = app.end_user_provisioning_service
     app_auth_service = app.app_auth_service
+    app_google_auth_service = app.app_google_auth_service
     push_service = app.push_service
 
     event_bus = events.event_bus

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -6,6 +6,8 @@ from dependency_injector import containers, providers
 
 from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
 from portal.application.auth.app_auth_service import AppAuthService
+from portal.application.auth.app_google_auth_service import AppGoogleAuthService
+from portal.application.auth.member_login_service import MemberLoginService
 from portal.application.bible.bible_service import BibleService
 from portal.application.push.push_service import PushService
 from portal.config import settings as app_settings
@@ -52,16 +54,29 @@ class AppContainer(containers.DeclarativeContainer):
     otp_mailer = providers.Singleton(OtpMailer)
 
     member_web_app_registry = providers.Singleton(lambda: MemberWebAppRegistry(parse_member_web_apps(app_settings.MEMBER_WEB_APPS)))
+    member_login_service = providers.Factory(
+        MemberLoginService,
+        user_repository=user_repository,
+        preferences_repository=preferences_repository,
+        jwt_provider=core.jwt_provider,
+        refresh_token_provider=core.refresh_token_provider,
+        member_refresh_app_binding_provider=core.member_refresh_app_binding_provider,
+        member_web_app_registry=member_web_app_registry,
+    )
     app_auth_service = providers.Factory(
         AppAuthService,
         provisioning_service=end_user_provisioning_service,
         user_repository=user_repository,
         end_user_repository=end_user_repository,
-        preferences_repository=preferences_repository,
         otp_token_store=otp_token_store,
         otp_mailer=otp_mailer,
-        jwt_provider=core.jwt_provider,
-        refresh_token_provider=core.refresh_token_provider,
-        member_refresh_app_binding_provider=core.member_refresh_app_binding_provider,
-        member_web_app_registry=member_web_app_registry,
+        member_login_service=member_login_service,
+    )
+    app_google_auth_service = providers.Factory(
+        AppGoogleAuthService,
+        provisioning_service=end_user_provisioning_service,
+        user_repository=user_repository,
+        end_user_repository=end_user_repository,
+        google_id_token_verifier=core.google_id_token_verifier,
+        member_login_service=member_login_service,
     )

--- a/portal/routers/apis/v1/auth.py
+++ b/portal/routers/apis/v1/auth.py
@@ -6,13 +6,14 @@ from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, status
 
 from portal.application.auth.app_auth_service import AppAuthService
-from portal.application.auth.commands import AppOtpRequestCommand, AppOtpVerifyCommand, LogoutCommand, RefreshTokenCommand
+from portal.application.auth.app_google_auth_service import AppGoogleAuthService
+from portal.application.auth.commands import AppGoogleLoginCommand, AppOtpRequestCommand, AppOtpVerifyCommand, LogoutCommand, RefreshTokenCommand
 from portal.application.auth.mappers import member_login_result_to_api, otp_request_result_to_api, token_result_to_api
 from portal.application.auth.refresh_token_service import RefreshTokenService
 from portal.container import Container
 from portal.libs.depends.rate_limiters import WRITE_RATE_LIMITERS
 from portal.routers.auth_router import AuthRouter
-from portal.serializers.apis.v1.auth import MemberLoginResponse, MemberOtpRequest, MemberOtpRequestResponse, MemberOtpVerifyRequest
+from portal.serializers.apis.v1.auth import MemberGoogleLoginRequest, MemberLoginResponse, MemberOtpRequest, MemberOtpRequestResponse, MemberOtpVerifyRequest
 from portal.serializers.mixins import LogoutRequest, LogoutResponse, RefreshTokenRequest, TokenResponse
 
 router: AuthRouter = AuthRouter()
@@ -52,6 +53,23 @@ async def app_request_otp(body: MemberOtpRequest, app_auth_service: AppAuthServi
 @inject
 async def app_verify_otp(body: MemberOtpVerifyRequest, app_auth_service: AppAuthService = Depends(Provide[Container.app_auth_service])):
     result = await app_auth_service.verify_otp(AppOtpVerifyCommand(email=body.email, code=body.code))
+    return member_login_result_to_api(result)
+
+
+@router.post(
+    "/google",
+    response_model=MemberLoginResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_200_OK,
+    require_auth=False,
+    dependencies=[*WRITE_RATE_LIMITERS],
+    operation_id="member_google_login",
+    summary="Sign in with Google",
+    description="Resolve a verified Google ID token to an End user, provisioning the account on first success. Every rejection returns the same generic 401.",
+)
+@inject
+async def app_google_login(body: MemberGoogleLoginRequest, app_google_auth_service: AppGoogleAuthService = Depends(Provide[Container.app_google_auth_service])):
+    result = await app_google_auth_service.login_with_google(AppGoogleLoginCommand(id_token=body.id_token))
     return member_login_result_to_api(result)
 
 

--- a/portal/serializers/apis/v1/auth.py
+++ b/portal/serializers/apis/v1/auth.py
@@ -25,6 +25,12 @@ class MemberOtpVerifyRequest(BaseModel):
     code: str = Field(..., min_length=6, max_length=6, pattern=r"^\d{6}$", description="Six-digit one-time passcode")
 
 
+class MemberGoogleLoginRequest(BaseModel):
+    """End-user Google ID-token sign-in request body (ADR 0008)."""
+
+    id_token: str = Field(..., description="Google ID token from the app's Google sign-in client")
+
+
 class MemberOtpRequestResponse(BaseModel):
     """Anti-enumeration acknowledgement."""
 

--- a/tests/application/auth/test_app_auth_service.py
+++ b/tests/application/auth/test_app_auth_service.py
@@ -14,6 +14,7 @@ import pytest
 
 from portal.application.auth.app_auth_service import AppAuthService
 from portal.application.auth.commands import AppOtpRequestCommand, AppOtpVerifyCommand
+from portal.application.auth.member_login_service import MemberLoginService
 from portal.application.auth.results import MemberLoginResult, UserSensitive
 from portal.domain.app.entities import EndUser, UserPreferences
 from portal.exceptions.responses import TooManyRequestsException, UnauthorizedException
@@ -158,17 +159,21 @@ def _build_service() -> tuple[AppAuthService, StubUserRepository, StubEndUserRep
     provisioning = EndUserProvisioningService(
         user_repository=user_repo, end_user_repository=end_user_repo, preferences_repository=prefs_repo, password_provider=password
     )
-    service = AppAuthService(
-        provisioning_service=provisioning,
+    member_login_service = MemberLoginService(
         user_repository=user_repo,
-        end_user_repository=end_user_repo,
         preferences_repository=prefs_repo,
-        otp_token_store=token_store,
-        otp_mailer=mailer,
         jwt_provider=StubJwtProvider(),
         refresh_token_provider=StubRefreshTokenProvider(),
         member_refresh_app_binding_provider=StubMemberRefreshAppBindingProvider(),
         member_web_app_registry=StubMemberWebAppRegistry(),
+    )
+    service = AppAuthService(
+        provisioning_service=provisioning,
+        user_repository=user_repo,
+        end_user_repository=end_user_repo,
+        otp_token_store=token_store,
+        otp_mailer=mailer,
+        member_login_service=member_login_service,
     )
     return service, user_repo, end_user_repo, prefs_repo, mailer, token_store
 

--- a/tests/application/auth/test_app_google_auth_service.py
+++ b/tests/application/auth/test_app_google_auth_service.py
@@ -1,0 +1,383 @@
+"""
+Application-service seam: End-user Google ID-token sign-in (ADR 0008, stub verifier + stub repos).
+
+Parallel to the Admin Google tests, plus the branch the Admin flow deliberately lacks:
+a first success matching nothing provisions a brand-new Auth credential + End user +
+Preferences. Every rejection path fails with the same generic detail.
+"""
+
+from typing import Any, Optional
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.app_google_auth_service import GENERIC_FAILURE_DETAIL, AppGoogleAuthService
+from portal.application.auth.commands import AppGoogleLoginCommand
+from portal.application.auth.member_login_service import MemberLoginService
+from portal.application.auth.results import MemberLoginResult, UserSensitive
+from portal.domain.app.entities import EndUser, UserPreferences
+from portal.domain.auth.entities import GoogleIdentityClaims
+from portal.exceptions.responses import UnauthorizedException
+
+ALLOWED_CLIENT_IDS = ["app-client-id"]
+
+
+class StubPasswordProvider:
+    def validate_password(self, password: str) -> bool:
+        return len(password) >= 8
+
+    def hash_password(self, password: str) -> str:
+        return f"hashed:{password}"
+
+
+class StubUserRepository:
+    """
+    Models one production detail the services depend on: `get_sensitive_by_email`
+    inner-joins the admin profile table, so it only ever sees credentials that have
+    an AuthUserProfile row. Credentials created by End-user provisioning have none.
+    """
+
+    def __init__(self):
+        self.by_email: dict[str, UserSensitive] = {}
+        self.by_id: dict[UUID, UserSensitive] = {}
+        self.emails_with_admin_profile: set[str] = set()
+        self.identity_links: dict[tuple[str, str], UUID] = {}
+        self.link_calls: list[dict[str, Any]] = []
+        self.google_provider_active = True
+        self.last_login_updates: list[UUID] = []
+
+    def seed_credential(
+        self, *, email: str, verified: bool = True, is_active: bool = True, is_admin: bool = False, has_admin_profile: bool = False
+    ) -> UserSensitive:
+        user = UserSensitive(
+            id=uuid4(), email=email, password_hash=None, verified=verified, is_active=is_active, is_admin=is_admin, first_name="", last_name=""
+        )
+        self.by_email[email.strip().lower()] = user
+        self.by_id[user.id] = user
+        if has_admin_profile:
+            self.emails_with_admin_profile.add(email.strip().lower())
+        return user
+
+    async def create_credential(
+        self, *, auth_user_id: UUID, email: str, password_hash: Optional[str], is_admin: bool, is_superuser: bool = False, verified: bool = False
+    ) -> UUID:
+        user = UserSensitive(
+            id=auth_user_id,
+            email=email,
+            password_hash=password_hash,
+            verified=verified,
+            is_active=True,
+            is_admin=is_admin,
+            is_superuser=is_superuser,
+            first_name="",
+            last_name="",
+        )
+        self.by_email[email] = user
+        self.by_id[auth_user_id] = user
+        return auth_user_id
+
+    async def identity_provider_is_active(self, code: str) -> bool:
+        assert code == "google"
+        return self.google_provider_active
+
+    async def get_user_id_by_identity_link(self, provider: str, provider_subject: str, provider_tenant: Optional[str] = None) -> Optional[UUID]:
+        return self.identity_links.get((provider, provider_subject))
+
+    async def upsert_identity_link(
+        self, user_id: UUID, provider: str, provider_subject: str, *, provider_tenant: Optional[str] = None, additional_data: Optional[dict[str, Any]] = None
+    ) -> None:
+        self.link_calls.append({"user_id": user_id, "provider": provider, "provider_subject": provider_subject, "additional_data": additional_data})
+        self.identity_links[(provider, provider_subject)] = user_id
+
+    async def get_sensitive_by_email(self, email: str) -> Optional[UserSensitive]:
+        key = email.strip().lower()
+        if key not in self.emails_with_admin_profile:
+            return None  # inner join on AuthUserProfile drops profile-less End user credentials
+        return self.by_email.get(key)
+
+    async def get_sensitive_by_email_without_profile(self, email: str) -> Optional[UserSensitive]:
+        return self.by_email.get(email.strip().lower())
+
+    async def get_sensitive_by_id(self, user_id: UUID) -> Optional[UserSensitive]:
+        return self.by_id.get(user_id)
+
+    async def update_last_login_at(self, user_id: UUID, last_login_at) -> None:
+        self.last_login_updates.append(user_id)
+
+
+class StubEndUserRepository:
+    def __init__(self):
+        self.by_auth_user_id: dict[UUID, EndUser] = {}
+
+    def seed(self, auth_user_id: UUID) -> EndUser:
+        end_user = EndUser(id=uuid4(), auth_user_id=auth_user_id)
+        self.by_auth_user_id[auth_user_id] = end_user
+        return end_user
+
+    async def create_end_user(self, *, end_user_id: UUID, auth_user_id: UUID) -> EndUser:
+        end_user = EndUser(id=end_user_id, auth_user_id=auth_user_id)
+        self.by_auth_user_id[auth_user_id] = end_user
+        return end_user
+
+    async def get_by_auth_user_id(self, auth_user_id: UUID):
+        return self.by_auth_user_id.get(auth_user_id)
+
+
+class StubPreferencesRepository:
+    def __init__(self):
+        self.by_user_id: dict[UUID, UserPreferences] = {}
+
+    async def create_preferences(self, preferences: UserPreferences) -> UserPreferences:
+        self.by_user_id[preferences.user_id] = preferences
+        return preferences
+
+    async def get_by_user_id(self, user_id: UUID):
+        return self.by_user_id.get(user_id)
+
+
+class StubGoogleIdTokenVerifier:
+    def __init__(self):
+        self.claims_by_token: dict[str, GoogleIdentityClaims] = {}
+
+    def register(self, token: str, claims: GoogleIdentityClaims) -> None:
+        self.claims_by_token[token] = claims
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[GoogleIdentityClaims]:
+        claims = self.claims_by_token.get(id_token)
+        if not claims or claims.audience not in audiences:
+            return None
+        return claims
+
+
+class StubJwtProvider:
+    def create_access_token(self, *args, **kwargs) -> str:
+        return "access-token"
+
+
+class StubRefreshTokenProvider:
+    async def issue(self, *, user_id: UUID, device_id: UUID, family_id: UUID) -> str:
+        return "refresh-token"
+
+
+class StubMemberRefreshAppBindingProvider:
+    def __init__(self):
+        self.bound: list[tuple] = []
+
+    async def bind(self, family_id: UUID, app_code: str) -> None:
+        self.bound.append((family_id, app_code))
+
+
+class StubMemberWebAppRegistry:
+    def __init__(self, default_code: str = "rooted-app"):
+        self._default_code = default_code
+
+    @property
+    def default_app_code(self) -> str:
+        return self._default_code
+
+    def resolve_app_code(self, origin=None, referer=None):
+        return None
+
+
+def _build_service(
+    monkeypatch: pytest.MonkeyPatch, client_ids: list[str] = ALLOWED_CLIENT_IDS
+) -> tuple[AppGoogleAuthService, StubUserRepository, StubEndUserRepository, StubPreferencesRepository, StubGoogleIdTokenVerifier]:
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "GOOGLE_APP_CLIENT_IDS", ",".join(client_ids))
+
+    user_repo = StubUserRepository()
+    end_user_repo = StubEndUserRepository()
+    prefs_repo = StubPreferencesRepository()
+    verifier = StubGoogleIdTokenVerifier()
+    provisioning = EndUserProvisioningService(
+        user_repository=user_repo, end_user_repository=end_user_repo, preferences_repository=prefs_repo, password_provider=StubPasswordProvider()
+    )
+    member_login_service = MemberLoginService(
+        user_repository=user_repo,
+        preferences_repository=prefs_repo,
+        jwt_provider=StubJwtProvider(),
+        refresh_token_provider=StubRefreshTokenProvider(),
+        member_refresh_app_binding_provider=StubMemberRefreshAppBindingProvider(),
+        member_web_app_registry=StubMemberWebAppRegistry(),
+    )
+    service = AppGoogleAuthService(
+        provisioning_service=provisioning,
+        user_repository=user_repo,
+        end_user_repository=end_user_repo,
+        google_id_token_verifier=verifier,
+        member_login_service=member_login_service,
+    )
+    return service, user_repo, end_user_repo, prefs_repo, verifier
+
+
+def _claims(subject: str = "google-sub-1", email: str = "jay@example.com", email_verified: bool = True, audience: str = "app-client-id"):
+    return GoogleIdentityClaims(subject=subject, email=email, email_verified=email_verified, audience=audience)
+
+
+@pytest.mark.asyncio
+async def test_first_success_provisions_a_brand_new_account_and_links_it(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, prefs_repo, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims(email="Jay@Example.com"))
+
+    result = await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+
+    assert isinstance(result, MemberLoginResult)
+    credential = user_repo.by_email["jay@example.com"]
+    assert credential.password_hash is None
+    assert credential.verified is True
+    end_user = end_user_repo.by_auth_user_id[credential.id]
+    assert result.member.id == end_user.id
+    assert result.member.id != credential.id
+    assert prefs_repo.by_user_id[end_user.id].display_name == "jay"
+    assert user_repo.link_calls == [
+        {"user_id": credential.id, "provider": "google", "provider_subject": "google-sub-1", "additional_data": {"email": "Jay@Example.com"}}
+    ]
+    assert result.token.access_token == "access-token"
+    assert result.token.refresh_token == "refresh-token"
+
+
+@pytest.mark.asyncio
+async def test_later_success_resolves_by_subject_without_provisioning_again(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims())
+    first = await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+
+    # Remove the email match path entirely — only the Identity link should resolve the account now.
+    user_repo.by_email.clear()
+    verifier.register("token-2", _claims())
+
+    second = await service.login_with_google(AppGoogleLoginCommand(id_token="token-2"))
+
+    assert second.member.id == first.member.id
+    assert len(end_user_repo.by_auth_user_id) == 1
+    assert len(user_repo.link_calls) == 1  # no re-upsert needed on subject-match path
+
+
+@pytest.mark.asyncio
+async def test_verified_email_matches_an_existing_end_user_and_upserts_the_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    credential = user_repo.seed_credential(email="jay@example.com")
+    end_user = end_user_repo.seed(credential.id)
+    verifier.register("token-1", _claims(email="JAY@example.com"))
+
+    result = await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+
+    assert result.member.id == end_user.id
+    assert len(end_user_repo.by_auth_user_id) == 1  # matched, never duplicated
+    assert user_repo.link_calls[0]["user_id"] == credential.id
+
+
+@pytest.mark.asyncio
+async def test_matches_an_otp_provisioned_account_which_has_no_admin_profile_row(monkeypatch: pytest.MonkeyPatch):
+    """
+    Parent story 8: a later Google sign-in with the same verified email must land on the
+    existing account, not a duplicate. End-user credentials have no AuthUserProfile row,
+    so the email lookup must not be the profile-joining one.
+    """
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    credential = user_repo.seed_credential(email="jay@example.com")  # no admin profile, as OTP provisioning leaves it
+    end_user = end_user_repo.seed(credential.id)
+    verifier.register("token-1", _claims())
+
+    result = await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+
+    assert result.member.id == end_user.id
+    assert len(end_user_repo.by_auth_user_id) == 1
+    assert len(user_repo.by_email) == 1  # no second credential created
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_provider_inactive(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, _end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    user_repo.google_provider_active = False
+    verifier.register("token-1", _claims())
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_when_client_id_allowlist_empty(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch, client_ids=[])
+    verifier.register("token-1", _claims())
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert end_user_repo.by_auth_user_id == {}
+
+
+@pytest.mark.asyncio
+async def test_rejects_invalid_token(monkeypatch: pytest.MonkeyPatch):
+    service, _user_repo, end_user_repo, _prefs, _verifier = _build_service(monkeypatch)
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="not-a-registered-token"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert end_user_repo.by_auth_user_id == {}
+
+
+@pytest.mark.asyncio
+async def test_rejects_wrong_audience(monkeypatch: pytest.MonkeyPatch):
+    service, _user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims(audience="other-client-id"))
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert end_user_repo.by_auth_user_id == {}
+
+
+@pytest.mark.asyncio
+async def test_rejects_unverified_email_and_never_provisions(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims(email_verified=False))
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert end_user_repo.by_auth_user_id == {}
+    assert user_repo.by_email == {}
+
+
+@pytest.mark.asyncio
+async def test_rejects_inactive_credential_and_does_not_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    credential = user_repo.seed_credential(email="jay@example.com", is_active=False)
+    end_user_repo.seed(credential.id)
+    verifier.register("token-1", _claims())
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_admin_only_credential_without_an_end_user(monkeypatch: pytest.MonkeyPatch):
+    """An admin console credential has no app.user row; Google app sign-in must not attach product identity to it."""
+    service, user_repo, _end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    user_repo.seed_credential(email="admin-only@example.com", is_admin=True, has_admin_profile=True)
+    verifier.register("token-1", _claims(email="admin-only@example.com"))
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL
+    assert user_repo.link_calls == []
+
+
+@pytest.mark.asyncio
+async def test_rejects_linked_subject_whose_credential_was_deactivated(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, _end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims())
+    await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+
+    user_repo.by_id[user_repo.link_calls[0]["user_id"]].is_active = False
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_google(AppGoogleLoginCommand(id_token="token-1"))
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL


### PR DESCRIPTION
## Summary

Gives End users the Google ID-token sign-in that ADR 0005 reserved Identity-link schema for, reusing the existing `GoogleIdTokenVerifierPort`. Resolution order: existing Identity link by `sub`, else a verified-email match to an existing End user's credential (upserting the link), else provision a brand-new Auth credential + End user + Preferences — the "may create on first success" branch the Admin flow deliberately lacks.

Closes #35.

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- The email lookup is `get_sensitive_by_email_without_profile`, **not** the Admin flow's `get_sensitive_by_email`. The latter inner-joins `auth.user_profile`, which End-user credentials never have, so it would miss every existing End user and then collide on re-provisioning. `StubUserRepository` now models that join, so the seam catches this class of bug (reverting the fix turns 5 tests red).
- An admin-only credential (no `app.user` row) is refused, exactly as magic-link verify already refuses it, rather than attaching product identity to a console account.
- Every rejection path raises the same generic detail, mirroring `AdminGoogleAuthService`.
- Member token issuance moves out of `AppAuthService` into a shared `MemberLoginService` — the app-side counterpart of `LoginService` — so both End-user sign-in paths issue tokens through one place.
- New `GOOGLE_APP_CLIENT_IDS` allowlist; empty disables the flow.
- HTTP: `POST /api/v1/auth/google`.

## Testing

- [x] `uv run pytest` — 112 passed
- [x] `uv run ruff format` / `uv run ruff check` on the files this branch touches

## Merge order

Touches `AppAuthService` alongside #34 and #38; expect a manual conflict resolution for whichever merges second.

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge
