### PR TITLE
feat(push): carry a locale per Device and localize push copy per device

### DIFF
--- a/docs/migrations/0037-device-locale-checklist.md
+++ b/docs/migrations/0037-device-locale-checklist.md
@@ -1,0 +1,26 @@
+# Human Alembic checklist — add `push.device.locale` (#37 / ADR 0009)
+
+Agents must **not** add, modify, or delete files under `alembic/versions/`. The ORM change is on the feature branch; this delta still needs a human-authored revision.
+
+## Status
+
+**Pending.** `PushDevice`, the Device entity, the repository, and the registration endpoint all carry `locale`; the database does not yet.
+
+## Goal
+
+Give each Device its own last-known system locale, so push copy is composed in the language that specific install is set to instead of one language for the whole account.
+
+## Suggested steps
+
+1. **Autogenerate** after the ORM change is on the branch:
+   - `uv run alembic revision --autogenerate -m "add_push_device_locale"`
+2. **Review the revision** for exactly one change:
+   - `op.add_column("device", sa.Column("locale", sa.String(20), nullable=True), schema="push")`
+   - **Nullable, no server default** — devices registered before the client started sending a locale legitimately have none, and `PushService.notify` falls back to the default copy for them.
+3. **Apply locally:** `uv run alembic upgrade head`
+4. **Smoke:** `PUT /api/v1/push/devices/{device_key}` with and without `locale` in the body; re-registering the same `device_key` with a different locale overwrites it.
+
+## Out of scope
+
+- Backfilling a locale onto existing Device rows (there is no per-device value to backfill from — the client sends one on its next registration call)
+- Any account-level locale (dropped in #36)

--- a/portal/application/push/push_service.py
+++ b/portal/application/push/push_service.py
@@ -9,7 +9,7 @@ from uuid import UUID
 from portal.application.push.results import DeviceResult, NotificationResult
 from portal.domain.app.ports import EndUserRepositoryPort
 from portal.domain.push.constants import DeliveryStatus, PushSendStatus
-from portal.domain.push.entities import NotificationDeliveryDraft
+from portal.domain.push.entities import Device, LocalizedNotificationCopy, NotificationDeliveryDraft
 from portal.domain.push.ports import DeviceRepositoryPort, NotificationRepositoryPort, PushGatewayPort
 from portal.libs.logger import logger
 from portal.libs.tracing.distributed_trace import distributed_trace
@@ -39,55 +39,80 @@ class PushService:
         return end_user.id if end_user else None
 
     @distributed_trace()
-    async def register_device(self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID]) -> DeviceResult:
+    async def register_device(
+        self, *, device_key: str, token: str, platform: str, app_version: Optional[str], locale: Optional[str], end_user_id: Optional[UUID]
+    ) -> DeviceResult:
         """
         Upsert by device_key: unconditionally overwrite token/platform/app_version/
-        last_used_at, and set end_user_id to whatever this call resolved (the
+        locale/last_used_at, and set end_user_id to whatever this call resolved (the
         signed-in End user's id, or None if unauthenticated).
         """
         return await self._device_repository.upsert_device(
-            device_key=device_key, token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=datetime.now(timezone.utc)
+            device_key=device_key,
+            token=token,
+            platform=platform,
+            app_version=app_version,
+            locale=locale,
+            end_user_id=end_user_id,
+            last_used_at=datetime.now(timezone.utc),
         )
 
+    @staticmethod
+    def _group_by_locale(devices: list[Device]) -> dict[Optional[str], list[Device]]:
+        """Bucket devices by their own locale, preserving the repository's order."""
+        groups: dict[Optional[str], list[Device]] = {}
+        for device in devices:
+            groups.setdefault(device.locale, []).append(device)
+        return groups
+
     @distributed_trace()
-    async def notify(self, *, end_user_id: UUID, category: str, title: str, body: str, data: Optional[dict] = None) -> NotificationResult:
+    async def notify(self, *, end_user_id: UUID, category: str, copy: LocalizedNotificationCopy, data: Optional[dict] = None) -> NotificationResult:
         """
-        Create a Notification for an End user and fan it out to every active
-        Device it owns. Zero active devices is a valid no-op (the Notification
-        row is still created). Never raises to the caller — a gateway
-        exception becomes a failed NotificationDelivery per device instead.
+        Create a Notification for an End user and fan it out to every active Device
+        it owns, one send per distinct Device locale so each install gets copy in the
+        language it is actually set to (ADR 0009). Zero active devices is a valid
+        no-op (the Notification row is still created). Never raises to the caller — a
+        gateway exception becomes a failed NotificationDelivery for that group's devices.
         """
-        notification = await self._notification_repository.create_notification(end_user_id=end_user_id, category=category, title=title, body=body, data=data)
+        notification = await self._notification_repository.create_notification(
+            end_user_id=end_user_id, category=category, title=copy.default.title, body=copy.default.body, data=data
+        )
 
         devices = await self._device_repository.list_active_devices(end_user_id)
         if not devices:
             return notification
 
-        try:
-            send_results = await self._push_gateway.send_multicast(tokens=[device.token for device in devices], title=title, body=body, data=data)
-        except Exception as error:
-            logger.warning(f"Push gateway send_multicast failed for notification {notification.id}: {error}")
-            await self._notification_repository.record_deliveries(
-                [
-                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=str(error))
-                    for device in devices
-                ]
-            )
-            return notification
-
         deliveries: list[NotificationDeliveryDraft] = []
         unregistered_device_ids: list[UUID] = []
-        delivered_at = datetime.now(timezone.utc)
-        for device, result in zip(devices, send_results):
-            if result.status == PushSendStatus.SUCCESS:
-                deliveries.append(
-                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.SUCCESS, delivered_at=delivered_at)
+        for locale, group in self._group_by_locale(devices).items():
+            group_copy = copy.for_locale(locale)
+            try:
+                send_results = await self._push_gateway.send_multicast(
+                    tokens=[device.token for device in group], title=group_copy.title, body=group_copy.body, data=data
+                )
+            except Exception as error:
+                logger.warning(f"Push gateway send_multicast failed for notification {notification.id} (locale {locale}): {error}")
+                deliveries.extend(
+                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=str(error))
+                    for device in group
                 )
                 continue
 
-            deliveries.append(NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=result.error))
-            if result.status == PushSendStatus.UNREGISTERED:
-                unregistered_device_ids.append(device.id)
+            delivered_at = datetime.now(timezone.utc)
+            for device, result in zip(group, send_results):
+                if result.status == PushSendStatus.SUCCESS:
+                    deliveries.append(
+                        NotificationDeliveryDraft(
+                            notification_id=notification.id, device_id=device.id, status=DeliveryStatus.SUCCESS, delivered_at=delivered_at
+                        )
+                    )
+                    continue
+
+                deliveries.append(
+                    NotificationDeliveryDraft(notification_id=notification.id, device_id=device.id, status=DeliveryStatus.FAILED, error=result.error)
+                )
+                if result.status == PushSendStatus.UNREGISTERED:
+                    unregistered_device_ids.append(device.id)
 
         await self._notification_repository.record_deliveries(deliveries)
         if unregistered_device_ids:

--- a/portal/domain/push/entities.py
+++ b/portal/domain/push/entities.py
@@ -29,6 +29,9 @@ class Device(UUIDBaseModel):
     is_active: bool = Field(default=True, description="Whether this device should receive pushes")
     last_used_at: datetime = Field(..., description="Last time this device registered/refreshed")
     app_version: Optional[str] = Field(default=None, description="Client app version at last registration")
+    locale: Optional[str] = Field(
+        default=None, description="This install's last-known system locale (ADR 0009); None for devices registered before the client sent one"
+    )
 
 
 class Notification(UUIDBaseModel):
@@ -61,6 +64,32 @@ class NotificationDeliveryDraft(BaseModel):
     status: DeliveryStatus
     error: Optional[str] = None
     delivered_at: Optional[datetime] = None
+
+
+class NotificationCopy(BaseModel):
+    """The title/body a Notification shows, in one language."""
+
+    title: str = Field(..., description="Notification title")
+    body: str = Field(..., description="Notification body")
+
+
+class LocalizedNotificationCopy(BaseModel):
+    """
+    A Notification's copy in every language the caller could author it in.
+
+    How a category maps to actual wording is the caller's business (ADR 0009 only
+    makes the fan-out locale-aware); `default` covers every Device whose locale has
+    no entry, including devices with no known locale at all.
+    """
+
+    default: NotificationCopy = Field(..., description="Copy used when a Device's locale has no dedicated entry")
+    by_locale: dict[str, NotificationCopy] = Field(default_factory=dict, description="Copy keyed by locale code")
+
+    def for_locale(self, locale: Optional[str]) -> NotificationCopy:
+        """Resolve the copy a Device in `locale` should receive."""
+        if locale is None:
+            return self.default
+        return self.by_locale.get(locale, self.default)
 
 
 class PushSendResult(BaseModel):

--- a/portal/domain/push/ports.py
+++ b/portal/domain/push/ports.py
@@ -13,11 +13,19 @@ class DeviceRepositoryPort(Protocol):
     """Persist push Device rows keyed by device_key."""
 
     async def upsert_device(
-        self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID], last_used_at: datetime
+        self,
+        *,
+        device_key: str,
+        token: str,
+        platform: str,
+        app_version: Optional[str],
+        locale: Optional[str],
+        end_user_id: Optional[UUID],
+        last_used_at: datetime,
     ) -> Device:
         """
         Insert a Device on first registration, or overwrite token/platform/
-        app_version/last_used_at/end_user_id on every subsequent call.
+        app_version/locale/last_used_at/end_user_id on every subsequent call.
         """
 
     async def list_active_devices(self, end_user_id: UUID) -> list[Device]:

--- a/portal/infrastructure/persistence/repositories/push/device_repository.py
+++ b/portal/infrastructure/persistence/repositories/push/device_repository.py
@@ -25,22 +25,38 @@ class DeviceRepository:
         PushDevice.is_active,
         PushDevice.last_used_at,
         PushDevice.app_version,
+        PushDevice.locale,
     )
 
     def __init__(self, session: Session):
         self._session = session
 
     async def upsert_device(
-        self, *, device_key: str, token: str, platform: str, app_version: Optional[str], end_user_id: Optional[UUID], last_used_at: datetime
+        self,
+        *,
+        device_key: str,
+        token: str,
+        platform: str,
+        app_version: Optional[str],
+        locale: Optional[str],
+        end_user_id: Optional[UUID],
+        last_used_at: datetime,
     ) -> Device:
         await (
             self._session.insert(PushDevice)
             .values(
-                id=uuid4(), device_key=device_key, token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=last_used_at
+                id=uuid4(),
+                device_key=device_key,
+                token=token,
+                platform=platform,
+                app_version=app_version,
+                locale=locale,
+                end_user_id=end_user_id,
+                last_used_at=last_used_at,
             )
             .on_conflict_do_update(
                 index_elements=["device_key"],
-                set_=dict(token=token, platform=platform, app_version=app_version, end_user_id=end_user_id, last_used_at=last_used_at),
+                set_=dict(token=token, platform=platform, app_version=app_version, locale=locale, end_user_id=end_user_id, last_used_at=last_used_at),
             )
             .execute()
         )

--- a/portal/models/push/device.py
+++ b/portal/models/push/device.py
@@ -34,3 +34,4 @@ class PushDevice(ModelBase, AuditMixin):
     is_active = Column(sa.Boolean, nullable=False, server_default=sa.text("true"), comment="Whether this device should receive pushes")
     last_used_at = Column(sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now(), comment="Last time this device registered/refreshed")
     app_version = Column(sa.String(32), nullable=True, comment="Client app version at last registration")
+    locale = Column(sa.String(20), nullable=True, comment="This install's last-known system locale, used to localize push copy (ADR 0009)")

--- a/portal/routers/apis/v1/push.py
+++ b/portal/routers/apis/v1/push.py
@@ -29,7 +29,8 @@ router: AuthRouter = AuthRouter()
     summary="Register or refresh a push device",
     description=(
         "Upsert a push Device by device_key. Authorization is optional: when present it must verify "
-        "(invalid/expired tokens still 401), and end_user_id is always overwritten to whatever this call resolved."
+        "(invalid/expired tokens still 401), and end_user_id is always overwritten to whatever this call resolved. "
+        "The locale sent here is what push copy for this device is localized into (ADR 0009)."
     ),
 )
 @inject
@@ -41,6 +42,6 @@ async def register_device(
     end_user_id = await push_service.resolve_end_user_id(auth_user_id)
 
     result = await push_service.register_device(
-        device_key=device_key, token=body.token, platform=body.platform, app_version=body.app_version, end_user_id=end_user_id
+        device_key=device_key, token=body.token, platform=body.platform, app_version=body.app_version, locale=body.locale, end_user_id=end_user_id
     )
     return device_to_api(result)

--- a/portal/serializers/apis/v1/push.py
+++ b/portal/serializers/apis/v1/push.py
@@ -15,6 +15,9 @@ class DeviceRegistrationRequest(BaseModel):
     token: str = Field(..., description="Current push token (FCM/APNs-via-FCM)")
     platform: Literal["ios", "android"] = Field(..., description="Platform: ios|android")
     app_version: Optional[str] = Field(default=None, description="Client app version")
+    locale: Optional[str] = Field(
+        default=None, max_length=20, description="This install's current system locale (e.g. zh-Hant); push copy is localized per device"
+    )
 
 
 class DeviceRegistration(BaseModel):
@@ -27,6 +30,7 @@ class DeviceRegistration(BaseModel):
     is_active: bool = Field(..., serialization_alias="isActive")
     last_used_at: datetime = Field(..., serialization_alias="lastUsedAt")
     app_version: Optional[str] = Field(default=None, serialization_alias="appVersion")
+    locale: Optional[str] = Field(default=None, description="This install's last-known system locale")
 
     @field_serializer("id", "end_user_id")
     def serialize_uuid(self, value: Optional[UUID], _info) -> Optional[str]:

--- a/tests/application/push/test_push_service.py
+++ b/tests/application/push/test_push_service.py
@@ -10,14 +10,14 @@ import pytest
 from portal.application.push.push_service import PushService
 from portal.domain.app.entities import EndUser
 from portal.domain.push.constants import DeliveryStatus, PushSendStatus
-from portal.domain.push.entities import Device, Notification, PushSendResult
+from portal.domain.push.entities import Device, LocalizedNotificationCopy, Notification, NotificationCopy, PushSendResult
 
 
 class StubDeviceRepository:
     def __init__(self):
         self.devices: dict[str, Device] = {}
 
-    async def upsert_device(self, *, device_key, token, platform, app_version, end_user_id, last_used_at):
+    async def upsert_device(self, *, device_key, token, platform, app_version, locale, end_user_id, last_used_at):
         existing = self.devices.get(device_key)
         device = Device(
             id=existing.id if existing else uuid4(),
@@ -28,6 +28,7 @@ class StubDeviceRepository:
             is_active=existing.is_active if existing else True,
             last_used_at=last_used_at,
             app_version=app_version,
+            locale=locale,
         )
         self.devices[device_key] = device
         return device
@@ -93,12 +94,13 @@ def make_push_service(device_repository=None, end_user_repository=None, notifica
 @pytest.mark.asyncio
 async def test_register_device_anonymous_leaves_end_user_id_none():
     service = make_push_service()
-    result = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
+    result = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", locale="zh-Hant", end_user_id=None)
     assert result.end_user_id is None
     assert result.device_key == "device-1"
     assert result.token == "tok-1"
     assert result.platform == "ios"
     assert result.app_version == "1.0.0"
+    assert result.locale == "zh-Hant"
     assert result.is_active is True
 
 
@@ -106,7 +108,7 @@ async def test_register_device_anonymous_leaves_end_user_id_none():
 async def test_register_device_authenticated_sets_end_user_id():
     end_user_id = uuid4()
     service = make_push_service()
-    result = await service.register_device(device_key="device-1", token="tok-1", platform="android", app_version=None, end_user_id=end_user_id)
+    result = await service.register_device(device_key="device-1", token="tok-1", platform="android", app_version=None, locale=None, end_user_id=end_user_id)
     assert result.end_user_id == end_user_id
 
 
@@ -115,15 +117,16 @@ async def test_reregistering_same_device_key_overwrites_previous_owner():
     repository = StubDeviceRepository()
     service = make_push_service(device_repository=repository)
     first_owner = uuid4()
-    first = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=first_owner)
+    first = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", locale="zh-Hant", end_user_id=first_owner)
 
     second_owner = uuid4()
-    second = await service.register_device(device_key="device-1", token="tok-2", platform="ios", app_version="1.1.0", end_user_id=second_owner)
+    second = await service.register_device(device_key="device-1", token="tok-2", platform="ios", app_version="1.1.0", locale="en", end_user_id=second_owner)
 
     assert second.id == first.id
     assert second.end_user_id == second_owner
     assert second.token == "tok-2"
     assert second.app_version == "1.1.0"
+    assert second.locale == "en"  # a device whose system language changed re-registers with the new one
 
 
 @pytest.mark.asyncio
@@ -131,9 +134,9 @@ async def test_reregistering_unauthenticated_after_sign_in_clears_end_user_id():
     """Sign-out case: the client calls again without a bearer token, overwriting end_user_id back to None."""
     repository = StubDeviceRepository()
     service = make_push_service(device_repository=repository)
-    await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=uuid4())
+    await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", locale="zh-Hant", end_user_id=uuid4())
 
-    signed_out = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", end_user_id=None)
+    signed_out = await service.register_device(device_key="device-1", token="tok-1", platform="ios", app_version="1.0.0", locale="zh-Hant", end_user_id=None)
 
     assert signed_out.end_user_id is None
 
@@ -159,10 +162,21 @@ async def test_resolve_end_user_id_returns_none_when_auth_user_has_no_end_user()
     assert await service.resolve_end_user_id(uuid4()) is None
 
 
-def _make_device(end_user_id, token="tok", is_active=True) -> Device:
+def _make_device(end_user_id, token="tok", is_active=True, locale="zh-Hant") -> Device:
     return Device(
-        id=uuid4(), device_key=str(uuid4()), token=token, platform="ios", end_user_id=end_user_id, is_active=is_active, last_used_at=datetime.now(timezone.utc)
+        id=uuid4(),
+        device_key=str(uuid4()),
+        token=token,
+        platform="ios",
+        end_user_id=end_user_id,
+        is_active=is_active,
+        last_used_at=datetime.now(timezone.utc),
+        locale=locale,
     )
+
+
+def _copy(title="title", body="body", by_locale=None) -> LocalizedNotificationCopy:
+    return LocalizedNotificationCopy(default=NotificationCopy(title=title, body=body), by_locale=by_locale or {})
 
 
 @pytest.mark.asyncio
@@ -172,7 +186,7 @@ async def test_notify_with_zero_active_devices_is_a_no_op():
     service = make_push_service(notification_repository=notification_repository, push_gateway=push_gateway)
     end_user_id = uuid4()
 
-    result = await service.notify(end_user_id=end_user_id, category="prayer", title="Someone prayed", body="body")
+    result = await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy(title="Someone prayed"))
 
     assert result.end_user_id == end_user_id
     assert len(notification_repository.notifications) == 1
@@ -194,7 +208,7 @@ async def test_notify_fans_out_to_every_active_device_and_skips_inactive():
     push_gateway = StubPushGateway()
     service = make_push_service(device_repository=device_repository, push_gateway=push_gateway)
 
-    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+    await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy())
 
     assert set(push_gateway.calls[0]["tokens"]) == {"tok-active-1", "tok-active-2"}
 
@@ -212,7 +226,7 @@ async def test_notify_records_success_and_failed_deliveries():
     push_gateway = StubPushGateway(result_by_token={"tok-fail": PushSendResult(token="tok-fail", status=PushSendStatus.FAILED, error="boom")})
     service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
 
-    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+    await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy())
 
     deliveries_by_device = {delivery.device_id: delivery for delivery in notification_repository.recorded_deliveries}
     assert deliveries_by_device[ok_device.id].status == DeliveryStatus.SUCCESS
@@ -231,7 +245,7 @@ async def test_notify_deactivates_device_classified_unregistered():
     push_gateway = StubPushGateway(result_by_token={"tok-gone": PushSendResult(token="tok-gone", status=PushSendStatus.UNREGISTERED, error="not registered")})
     service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
 
-    await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+    await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy())
 
     assert device_repository.devices[unregistered_device.device_key].is_active is False
     delivery = notification_repository.recorded_deliveries[0]
@@ -250,7 +264,7 @@ async def test_notify_gateway_exception_records_failed_deliveries_and_does_not_r
     push_gateway = StubPushGateway(raise_error=RuntimeError("FCM unavailable"))
     service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
 
-    result = await service.notify(end_user_id=end_user_id, category="prayer", title="title", body="body")
+    result = await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy())
 
     assert result is not None
     assert len(notification_repository.recorded_deliveries) == 1
@@ -258,3 +272,125 @@ async def test_notify_gateway_exception_records_failed_deliveries_and_does_not_r
     assert delivery.status == DeliveryStatus.FAILED
     assert delivery.error == "FCM unavailable"
     assert device_repository.devices[device.device_key].is_active is True
+
+
+@pytest.mark.asyncio
+async def test_notify_sends_once_per_locale_group_with_that_group_s_copy():
+    """Two devices set to different system languages must each get copy in their own language."""
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    zh_device = _make_device(end_user_id, token="tok-zh", locale="zh-Hant")
+    en_device = _make_device(end_user_id, token="tok-en", locale="en")
+    second_zh_device = _make_device(end_user_id, token="tok-zh-2", locale="zh-Hant")
+    for device in (zh_device, en_device, second_zh_device):
+        device_repository.devices[device.device_key] = device
+
+    push_gateway = StubPushGateway()
+    notification_repository = StubNotificationRepository()
+    service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
+
+    copy = _copy(
+        title="Someone prayed",
+        body="Open Rooted to see it",
+        by_locale={
+            "zh-Hant": NotificationCopy(title="有人為你禱告", body="打開 Rooted 看看"),
+            "en": NotificationCopy(title="Someone prayed for you", body="Open Rooted to see it"),
+        },
+    )
+    await service.notify(end_user_id=end_user_id, category="prayer", copy=copy)
+
+    assert len(push_gateway.calls) == 2
+    calls_by_title = {call["title"]: call for call in push_gateway.calls}
+    assert set(calls_by_title["有人為你禱告"]["tokens"]) == {"tok-zh", "tok-zh-2"}
+    assert calls_by_title["有人為你禱告"]["body"] == "打開 Rooted 看看"
+    assert calls_by_title["Someone prayed for you"]["tokens"] == ["tok-en"]
+
+    # every device still gets exactly one delivery row
+    assert len(notification_repository.recorded_deliveries) == 3
+    assert {delivery.status for delivery in notification_repository.recorded_deliveries} == {DeliveryStatus.SUCCESS}
+
+
+@pytest.mark.asyncio
+async def test_notify_single_locale_device_set_still_makes_exactly_one_send_call():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    for token in ("tok-1", "tok-2", "tok-3"):
+        device = _make_device(end_user_id, token=token, locale="zh-Hant")
+        device_repository.devices[device.device_key] = device
+
+    push_gateway = StubPushGateway()
+    service = make_push_service(device_repository=device_repository, push_gateway=push_gateway)
+
+    await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy(by_locale={"zh-Hant": NotificationCopy(title="標題", body="內文")}))
+
+    assert len(push_gateway.calls) == 1
+    assert set(push_gateway.calls[0]["tokens"]) == {"tok-1", "tok-2", "tok-3"}
+    assert push_gateway.calls[0]["title"] == "標題"
+
+
+@pytest.mark.asyncio
+async def test_notify_falls_back_to_default_copy_for_unknown_and_missing_locales():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    unknown_locale_device = _make_device(end_user_id, token="tok-ja", locale="ja")
+    no_locale_device = _make_device(end_user_id, token="tok-none", locale=None)
+    for device in (unknown_locale_device, no_locale_device):
+        device_repository.devices[device.device_key] = device
+
+    push_gateway = StubPushGateway()
+    service = make_push_service(device_repository=device_repository, push_gateway=push_gateway)
+
+    await service.notify(
+        end_user_id=end_user_id,
+        category="prayer",
+        copy=_copy(title="fallback", body="fallback body", by_locale={"en": NotificationCopy(title="english", body="english body")}),
+    )
+
+    assert len(push_gateway.calls) == 2  # "ja" and None are distinct groups
+    assert {call["title"] for call in push_gateway.calls} == {"fallback"}
+
+
+@pytest.mark.asyncio
+async def test_notify_gateway_failure_in_one_locale_group_does_not_stop_the_others():
+    end_user_id = uuid4()
+    device_repository = StubDeviceRepository()
+    zh_device = _make_device(end_user_id, token="tok-zh", locale="zh-Hant")
+    en_device = _make_device(end_user_id, token="tok-en", locale="en")
+    for device in (zh_device, en_device):
+        device_repository.devices[device.device_key] = device
+
+    class FailFirstGateway(StubPushGateway):
+        async def send_multicast(self, *, tokens, title, body, data):
+            if "tok-zh" in tokens:
+                self.calls.append({"tokens": tokens, "title": title, "body": body, "data": data})
+                raise RuntimeError("FCM unavailable")
+            return await super().send_multicast(tokens=tokens, title=title, body=body, data=data)
+
+    notification_repository = StubNotificationRepository()
+    push_gateway = FailFirstGateway()
+    service = make_push_service(device_repository=device_repository, notification_repository=notification_repository, push_gateway=push_gateway)
+
+    result = await service.notify(end_user_id=end_user_id, category="prayer", copy=_copy())
+
+    assert result is not None
+    deliveries_by_device = {delivery.device_id: delivery for delivery in notification_repository.recorded_deliveries}
+    assert deliveries_by_device[zh_device.id].status == DeliveryStatus.FAILED
+    assert deliveries_by_device[zh_device.id].error == "FCM unavailable"
+    assert deliveries_by_device[en_device.id].status == DeliveryStatus.SUCCESS
+
+
+@pytest.mark.asyncio
+async def test_notify_persists_the_default_copy_on_the_notification_row():
+    end_user_id = uuid4()
+    notification_repository = StubNotificationRepository()
+    service = make_push_service(notification_repository=notification_repository)
+
+    await service.notify(
+        end_user_id=end_user_id,
+        category="prayer",
+        copy=_copy(title="default title", body="default body", by_locale={"en": NotificationCopy(title="english", body="english body")}),
+    )
+
+    notification = notification_repository.notifications[0]
+    assert notification.title == "default title"
+    assert notification.body == "default body"

--- a/tests/models/push/test_push_device_schema.py
+++ b/tests/models/push/test_push_device_schema.py
@@ -26,3 +26,9 @@ def test_push_device_is_active_defaults_true() -> None:
     is_active = PushDevice.__table__.c.is_active
     assert is_active.nullable is False
     assert is_active.server_default is not None
+
+
+def test_push_device_carries_its_own_locale() -> None:
+    """ADR 0009: push copy is localized from the Device's own system locale, not an account preference."""
+    assert "locale" in PushDevice.__table__.c
+    assert PushDevice.__table__.c.locale.nullable is True


### PR DESCRIPTION
## Summary

Gives each Device its own last-known system locale and makes push copy follow it (ADR 0009). A person's two devices can be set to different system languages, so one `send_multicast` for the whole device list can no longer be right — the send path now buckets target devices by locale and issues one send per group with that group's copy.

Closes #37.

## Type of change

- [x] New feature or API
- [ ] Bug fix
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Device (entity, ORM, repository, registration endpoint) gains a nullable `locale`, overwritten on every registration/refresh call alongside token/platform/app_version — same unconditional-overwrite contract the other Device fields already have.
- `PushService.notify` now takes `LocalizedNotificationCopy` (a default plus copy keyed by locale). A single-locale device set still makes exactly one send call, so the common case is unchanged. Devices with an unknown or absent locale fall back to the default copy.
- A gateway failure in one locale group no longer skips the remaining groups; the failed group's devices get failed `NotificationDelivery` rows and the rest still send.
- The Notification row persists the default copy.
- The database delta is a **human-authored Alembic revision**, per the repo rule that agents must not touch `alembic/versions/**`. Checklist: `docs/migrations/0037-device-locale-checklist.md`.

## Testing

- [x] `uv run pytest` — 106 passed
- [x] `uv run ruff format` / `uv run ruff check` on the files this branch touches
- [ ] `uv run alembic upgrade head` after the migration is written

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge
