### PR TITLE
refactor(auth): retire End-user password login

### DIFF
--- a/portal/application/app/commands.py
+++ b/portal/application/app/commands.py
@@ -13,12 +13,12 @@ class ProvisionIdentityCommand(BaseModel):
     """
     Provision a shared auth credential.
 
-    When create_end_user is True (app signup), also create app.user + Preferences.
+    When create_end_user is True, also create app.user + Preferences.
     When False (admin-only), skip End user identity entirely.
     """
 
     email: str = Field(...)
-    password: Optional[str] = Field(default=None, description="Required for Admin/password paths; null for passwordless End users")
+    password: Optional[str] = Field(default=None, description="Required for Admin credential provisioning; null for End-user sign-in provisioning")
     display_name: Optional[str] = Field(default=None)
     create_end_user: bool = Field(default=True)
     is_admin: bool = Field(default=False)

--- a/portal/application/app/end_user_provisioning_service.py
+++ b/portal/application/app/end_user_provisioning_service.py
@@ -17,9 +17,10 @@ from portal.providers.password_provider import PasswordProvider
 
 class EndUserProvisioningService:
     """
-    App signup creates auth.user + app.user + Preferences together.
+    App sign-in provisioning creates auth.user + app.user + Preferences together.
     Admin-only provisioning creates the credential without app.user.
-    Password may be omitted for passwordless (email-OTP) End users.
+    End-user OTP and Identity-provider paths omit the password; shared Admin
+    credentials may still carry one.
     """
 
     def __init__(
@@ -55,8 +56,8 @@ class EndUserProvisioningService:
         display_name = self._default_display_name(email, command.display_name)
 
         auth_user_id = uuid.uuid4()
-        # OTP verify and password signup both mark verified for app use;
-        # admin-only rows stay unverified until an admin path confirms them.
+        # App sign-in provisioning marks the credential verified; admin-only
+        # rows stay unverified until an admin path confirms them.
         await self._user_repository.create_credential(
             auth_user_id=auth_user_id,
             email=email,

--- a/portal/application/auth/login_service.py
+++ b/portal/application/auth/login_service.py
@@ -8,7 +8,7 @@ from uuid import UUID, uuid4
 
 from portal.application.auth.commands import LoginCommand, LoginWithoutValidateCommand
 from portal.application.auth.mappers import normalize_user_for_token
-from portal.application.auth.results import AdminProfileResult, LoginResult, MemberLoginResult, MemberProfileResult, TokenResult, UserSensitive
+from portal.application.auth.results import AdminProfileResult, LoginResult, TokenResult, UserSensitive
 from portal.application.rbac.permission_service import PermissionService
 from portal.application.rbac.role_service import RoleService
 from portal.config import settings
@@ -18,7 +18,6 @@ from portal.libs.consts.enums import AccessTokenAudType
 from portal.libs.contexts.user_context import UserContext, get_user_context
 from portal.libs.tracing.distributed_trace import distributed_trace
 from portal.providers.jwt_provider import JWTProvider
-from portal.providers.member_refresh_app_binding_provider import MemberRefreshAppBindingProvider
 from portal.providers.password_provider import PasswordProvider
 from portal.providers.refresh_token_provider import RefreshTokenProvider
 
@@ -34,7 +33,6 @@ class LoginService:
         password_provider: PasswordProvider,
         role_service: RoleService,
         permission_service: PermissionService,
-        member_refresh_app_binding_provider: Optional[MemberRefreshAppBindingProvider] = None,
     ):
         self._expires_in = 60 * 60 * 24
         self._repository = user_repository
@@ -43,7 +41,6 @@ class LoginService:
         self._password_provider = password_provider
         self._role_service = role_service
         self._permission_service = permission_service
-        self._member_refresh_app_binding_provider = member_refresh_app_binding_provider
 
     @distributed_trace()
     async def login_with_password(self, command: LoginCommand) -> LoginResult:
@@ -86,57 +83,6 @@ class LoginService:
             last_login_at=user.last_login_at,
         )
         return LoginResult(admin=admin, token=token)
-
-    @distributed_trace()
-    async def complete_member_login(self, user: UserSensitive, app_code: str) -> MemberLoginResult:
-        if not user.verified or not user.is_active:
-            raise UnauthorizedException(detail="User is not allowed to access the app")
-        if not app_code:
-            raise UnauthorizedException(detail="Missing web app binding")
-
-        token_user = normalize_user_for_token(user)
-        family_id = uuid4()
-        device_id = uuid4()
-        access_token = self._jwt_provider.create_access_token(user=token_user, family_id=family_id, aud_type=AccessTokenAudType.USER, azp=app_code)
-        refresh_token = await self._refresh_token_provider.issue(user_id=user.id, device_id=device_id, family_id=family_id)
-        if self._member_refresh_app_binding_provider:
-            await self._member_refresh_app_binding_provider.bind(family_id, app_code)
-
-        now = datetime.now(timezone.utc)
-        await self._repository.update_last_login_at(user_id=user.id, last_login_at=now)
-
-        expires_in = settings.JWT_ACCESS_TOKEN_EXPIRE_MINUTES * 60
-        token = TokenResult(access_token=access_token, refresh_token=refresh_token, token_type="bearer", expires_in=expires_in)
-        member = MemberProfileResult(
-            id=user.id,
-            email=user.email or "",
-            first_name=user.first_name or "",
-            last_name=user.last_name or "",
-            preferred_name=user.preferred_name,
-            roles=[],
-            preferred_locale_id=user.preferred_locale_id,
-            last_login_at=user.last_login_at,
-        )
-        return MemberLoginResult(member=member, token=token)
-
-    @distributed_trace()
-    async def member_profile(self) -> MemberProfileResult:
-        ctx: Optional[UserContext] = get_user_context()
-        if not ctx or not ctx.user_id:
-            raise UnauthorizedException(detail="Unauthorized")
-        user = await self._repository.get_sensitive_by_id(ctx.user_id)
-        if not user:
-            raise UnauthorizedException(detail="User not found")
-        return MemberProfileResult(
-            id=user.id,
-            email=user.email or "",
-            first_name=user.first_name or "",
-            last_name=user.last_name or "",
-            preferred_name=user.preferred_name,
-            roles=[],
-            preferred_locale_id=user.preferred_locale_id,
-            last_login_at=user.last_login_at,
-        )
 
     @distributed_trace()
     async def admin_profile(self) -> AdminProfileResult:

--- a/portal/application/auth/member_web_app_resolver.py
+++ b/portal/application/auth/member_web_app_resolver.py
@@ -13,8 +13,8 @@ def resolve_request_app_code(registry: MemberWebAppRegistry, *, required: bool =
     """
     Resolve app_code from Origin (preferred) or Referer on the current request.
 
-    When Origin/Referer are absent (typical for native/Expo clients), fall back to
-    the registry default app code so password auth and refresh still work.
+    When Origin/Referer are absent (typical for native clients), fall back to
+    the registry default app code so member sign-in and refresh still work.
     :param registry:
     :param required:
     :return:

--- a/portal/containers/admin.py
+++ b/portal/containers/admin.py
@@ -83,7 +83,6 @@ class AdminContainer(containers.DeclarativeContainer):
         password_provider=core.password_provider,
         role_service=role_service,
         permission_service=permission_service,
-        member_refresh_app_binding_provider=core.member_refresh_app_binding_provider,
     )
     admin_google_auth_service = providers.Factory(
         AdminGoogleAuthService, user_repository=user_repository, google_id_token_verifier=core.google_id_token_verifier, login_service=login_service

--- a/tests/application/auth/test_login_service.py
+++ b/tests/application/auth/test_login_service.py
@@ -1,0 +1,45 @@
+"""Application-service seam: Admin password login remains supported."""
+
+from uuid import uuid4
+
+import pytest
+from pytest_mock import MockerFixture
+
+from portal.application.auth.commands import LoginCommand
+from portal.application.auth.login_service import LoginService
+from portal.application.auth.results import UserSensitive
+
+
+@pytest.mark.asyncio
+async def test_admin_can_log_in_with_password(mocker: MockerFixture) -> None:
+    user = UserSensitive(
+        id=uuid4(), email="admin@example.com", password_hash="hashed-password", verified=True, is_active=True, is_admin=True, first_name="Ada", last_name="Min"
+    )
+    user_repository = mocker.Mock()
+    user_repository.get_sensitive_by_email = mocker.AsyncMock(return_value=user)
+    user_repository.update_last_login_at = mocker.AsyncMock()
+    password_provider = mocker.Mock()
+    password_provider.verify_password.return_value = True
+    role_service = mocker.Mock()
+    role_service.init_user_roles_cache = mocker.AsyncMock(return_value=["admin"])
+    permission_service = mocker.Mock()
+    permission_service.init_user_permissions_cache = mocker.AsyncMock(return_value=["content:read"])
+    jwt_provider = mocker.Mock()
+    jwt_provider.create_access_token.return_value = "access-token"
+    refresh_token_provider = mocker.Mock()
+    refresh_token_provider.issue = mocker.AsyncMock(return_value="refresh-token")
+    service = LoginService(
+        user_repository=user_repository,
+        jwt_provider=jwt_provider,
+        refresh_token_provider=refresh_token_provider,
+        password_provider=password_provider,
+        role_service=role_service,
+        permission_service=permission_service,
+    )
+
+    result = await service.login_with_password(LoginCommand(email="admin@example.com", password="Secure1!"))
+
+    password_provider.verify_password.assert_called_once_with("Secure1!", "hashed-password")
+    assert result.admin.id == user.id
+    assert result.token.access_token == "access-token"
+    assert result.token.refresh_token == "refresh-token"

--- a/tests/routers/apis/v1/test_auth.py
+++ b/tests/routers/apis/v1/test_auth.py
@@ -1,0 +1,21 @@
+"""HTTP route contract for End-user and Admin authentication."""
+
+from fastapi.routing import APIRoute
+
+from portal.routers.admin.v1.auth import router as admin_auth_router
+from portal.routers.apis.v1.auth import router as app_auth_router
+
+
+def _post_paths(router) -> set[str]:
+    return {route.path for route in router.routes if isinstance(route, APIRoute) and "POST" in route.methods}
+
+
+def test_end_user_password_register_and_login_routes_are_unreachable() -> None:
+    post_paths = _post_paths(app_auth_router)
+
+    assert "/register" not in post_paths
+    assert "/login" not in post_paths
+
+
+def test_admin_password_login_route_remains_available() -> None:
+    assert "/login" in _post_paths(admin_auth_router)


### PR DESCRIPTION
## Summary

Retire the remaining End-user password login behavior from the backend while preserving Admin password authentication. Add regression coverage that keeps the End-user password routes unreachable and verifies Admin password login still issues tokens.

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [ ] Documentation only
- [x] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Remove obsolete member login/profile behavior from the Admin `LoginService`.
- Remove the now-unused member app binding dependency from the Admin container.
- Update stale password-auth wording in shared provisioning and member app resolution.
- Add HTTP route-contract coverage for the removed End-user password endpoints.
- Add application-service coverage for Admin password login.

Closes #39

## Testing

- [x] `uv run pytest` (134 passed)
- [x] `uv run ruff format` on changed files
- [x] `uv run ruff check --fix` on changed files

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge
