### PR TITLE
docs: calendar Daily lesson, Devotion pool, and Encounter streak ADRs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -7,7 +7,7 @@ Source of truth for product scope: `rooted-docs/docs/product/prd.md` (v1.0). Thi
 ## Product constraints agents must respect
 
 1. **Today devotion is primary; fellowship is secondary.** Opening the app meets Scripture first, not a timeline.
-2. **Walking with God > task completion.** Completing a day is **Amen** / encounter with God — not “check-in success” or streak shaming.
+2. **Walking with God > task completion.** Completing a day is an **Encounter day** (「今日已與主相遇」) — not “check-in success” or streak shaming.
 3. **No public square:** no likes, follows, leaderboards, or algorithmic discovery in v1.
 4. **Journal stays private:** journal entries, personal prayers, and private lesson notes never surface to groups or analytics content pipelines.
 5. **Small groups only:** target size 4–15; covenant before full fellowship features.
@@ -19,25 +19,29 @@ Source of truth for product scope: `rooted-docs/docs/product/prd.md` (v1.0). Thi
 
 ### Devotion
 
+**Devotion (靈修篇章)**:
+One authored piece of devotional content in the editorial pool: a Scripture **verse** reference plus reflection prompts, today's application, and prayer. Written by Rooted staff, versioned through `draft` → `ready`, and only becomes a **Daily lesson** once scheduled onto a date. Exists independently of any date — an unscheduled Devotion is real content, just not yet anyone's day. Its authored text lives in per-locale **Devotion translation** rows; a Devotion cannot reach `ready` until every locale active in the system locale catalog is filled.
+_Avoid_: calling an unscheduled piece a "daily lesson", storing the Scripture text on it (it holds a **Passage** reference; the text comes from the reader's **Bible version**), one row carrying all locales in JSONB, a hardcoded list of supported languages
+
 **Daily lesson (日課)**:
-The guided unit for a calendar day: passage, reflection prompts, prayer — the core “meet God today” experience.
-_Avoid_: generic “content item”, feed post
+A **Devotion** scheduled onto one calendar date — what the End user meets when they open Today. Identified by its date, not by a position in a course. The backend decides it; the End user never chooses it and the client never resolves it from a bundled catalog. A date with no scheduled Daily lesson is an operational gap that surfaces as an error, never as silently substituted content.
+_Avoid_: generic "content item", feed post, "day N of a series", letting the client pick the day's lesson, auto-filling an unscheduled date from the pool
 
-**Series**:
-An ordered collection of lessons (e.g. a 7-day plan). The platform publishes the catalog; users enroll via **Plan enrollment**.
-_Avoid_: playlist (too casual); treating the client bundle as the only authority
+**Devotion translation**:
+The authored text of one **Devotion** in one locale — reflection prompts, today's application, prayer. One row per locale, never one row carrying all locales. Every locale marked active in the system locale catalog must have a row before the Devotion can reach `ready`, so a reader is never served a half-translated day. No locale is privileged as a base — that idea only existed to name a fallback target, and there is no fallback. Does **not** carry Scripture text — that comes from the reader's **Bible version**.
+_Avoid_: JSONB multi-locale columns, falling back to another locale at read time, treating a missing translation as a runtime concern rather than a publishing gate, hardcoding the language list in devotion code, hanging the rule on the catalog's `is_default` flag (it governs unrelated admin-console behaviour)
 
-**Plan enrollment**:
-A user’s commitment to walk a series from a start date, with optional pause — tracks progress without public ranking.
-_Avoid_: subscription (billing connotation)
+**Encounter day (相遇日)**:
+A record that an End user met God through the **Daily lesson** on one calendar date — one row per user per date. Sign-in required, and recordable **only for the End user's own current local date** (BR-02): there is no backfilling a missed day. Marks spiritual rhythm, never gamified points exposed to others.
+_Avoid_: Amen (the word is a response of assent, not a completion; product copy now says 「今日已與主相遇」), Walk day (「同行」 already names the shepherd's pastoral view), check-in, backfill/make-up days, publicly comparable streaks
 
-**Amen / Walk day**:
-Recording that the user completed today’s devotion encounter for a date. Marks spiritual rhythm, not gamified streak points exposed to others.
-_Avoid_: check-in, streak (as product-facing shame mechanics)
+**Encounter streak**:
+How many consecutive dates an End user has an **Encounter day** for, shown only to that person. The **longest** streak is stored (it only ever grows, and only on a write); the **current** streak is stored alongside the last encounter date but must be re-validated against the reader's local date on every read — an untouched stored "current streak" silently rots the moment a day is missed, because nothing writes on the day someone stops.
+_Avoid_: trusting a stored current-streak value without date validation, exposing either number to other members, "streak broken" copy
 
 **Lesson note**:
-User text tied to a lesson (reflection, highlights). May sync to cloud in v1; **private** unless explicitly shared via fellowship **Share** with chosen privacy.
-_Avoid_: treating all notes as group-visible
+An End user's own writing for one calendar date — free note text plus optional answers to that day's reflection prompts, in one row per user per date. Sign-in required, and writable **only for the current local date**, like an **Encounter day**. Optional throughout: never required to record an Encounter day. **Private** unless explicitly shared via fellowship **Share** with chosen privacy.
+_Avoid_: treating all notes as group-visible, a separate store for reflection answers, keying the note to the pooled **Devotion** (a Devotion may be rescheduled; the writing belongs to the person's day, not to the content), requiring a note before an Encounter day
 
 ---
 
@@ -117,7 +121,7 @@ The product identity of someone using the Rooted app — anonymous for read-only
 _Avoid_: Member (as the identity noun — that word belongs to **Membership** roles), conflating with **Admin User**, using `auth.user.id` as the product member FK
 
 **Preferences**:
-End-user settings and presentation defaults (display name, theme, font scale, bible version, stage, reminder) — distinct from auth credentials, from **Admin User** profile fields, and from the End user identity key. Does **not** hold UI language: the App always follows the device's system language and never lets the End user override it in-app (ADR 0009).
+End-user settings and presentation defaults (display name, theme, font scale, bible version, stage, reminder, week start) — distinct from auth credentials, from **Admin User** profile fields, and from the End user identity key. Includes **week start** (`sunday` | `monday`, default `sunday`) — which day the Today screen's weekly rhythm bar begins on; a personal habit that follows the account across devices, unlike language. Does **not** hold UI language: the App always follows the device's system language and never lets the End user override it in-app (ADR 0009).
 _Avoid_: Admin User profile fields, burying prefs inside fellowship or journal rows, a stored `locale` column keyed to the account (language is per-device, not a synced account preference — see **Device**)
 
 **Admin User**:
@@ -186,4 +190,4 @@ _Avoid_: a per-End-user read/unread inbox (not yet modeled — future work)
 | PRD | `rooted-docs/docs/product/prd.md` |
 | API spec | `rooted-docs/docs/backend/api-specification.md` |
 | Database design | `rooted-docs/docs/backend/database-design.md` |
-| ADRs | `docs/adr/` (identity storage: ADR 0005; Admin Google: ADR 0006; direct FCM push: ADR 0007; End-user OTP/Google/Apple sign-in: ADR 0008; language follows device: ADR 0009) |
+| ADRs | `docs/adr/` (identity storage: ADR 0005; Admin Google: ADR 0006; direct FCM push: ADR 0007; End-user OTP/Google/Apple sign-in: ADR 0008; language follows device: ADR 0009; calendar Daily lesson & no series: ADR 0010; Devotion pool + schedule + per-locale translations: ADR 0011; Encounter streak storage: ADR 0012) |

--- a/docs/adr/0010-calendar-daily-lesson-remove-series-and-plans.md
+++ b/docs/adr/0010-calendar-daily-lesson-remove-series-and-plans.md
@@ -1,0 +1,38 @@
+# ADR 0010 — Today is a calendar Daily lesson; Series and Plan enrollment are removed
+
+## Status
+
+Accepted (2026-09-08). Supersedes the Series/Plan portions of ADR 0004's devotion scope. Formalises the `rooted-docs` PRD phase-1 override of 2026-08-27 ([rooted-docs#5](https://github.com/rooted-faith/rooted-docs/issues/5)) as an engineering decision, and extends it by removing the concepts outright rather than deferring them.
+
+## Context
+
+Rooted's devotion model was built around **Series** (an ordered course) and **Plan enrollment** (a user's commitment to walk one from a start date). The day's content was resolved client-side as `startedOn + N days` against a bundled catalog. `rooted-docs` still carries the full design — `series`, `lessons`, `plan_enrollments` tables, six `/devotion` endpoints — and `rooted_flutter` still ships `lib/features/plans/` with a `PlansBloc` wired into the Today screen and a `seriesId` on its `DailyLesson` model.
+
+The PRD already overrode the *product* scope in August: phase 1 has no series or plans, and Today is a single calendar daily lesson. But the *model* was left in place as "Future", which means every new piece of devotion work still has to answer "does this go through a series?" — and the client still owns the decision of which content a person sees on a given day.
+
+Product now also wants the day's content decided entirely by backend and operations staff. That is incompatible with keeping enrollment as the resolution mechanism, even a dormant one.
+
+## Decision
+
+1. **A Daily lesson is identified by its calendar date.** One date, one lesson, the same for every End user. There is no per-user content path.
+2. **The backend resolves it, not the client.** `GET /api/v1/devotion/today?date=YYYY-MM-DD` — the client supplies its own local calendar date (BR-02: the device's local date, never server or a fixed Asia/Taipei). The client no longer carries a content catalog.
+3. **Series and Plan enrollment are deleted, not deferred.** Removed from `CONTEXT.md`, from `rooted-docs` `database-design.md` (`series`, `lessons`, `plan_enrollments`) and `api-specification.md` (`/devotion/series`, `/devotion/series/{id}`, `/devotion/lessons/{lesson_id}`, `POST /devotion/enrollments`, `PATCH /devotion/enrollments/{series_id}`), and from `rooted_flutter` (`lib/features/plans/`, the `/plans` route, `DailyLesson.seriesId`).
+4. **The Scripture for a day is one verse**, held as a **Passage** reference (`passage_start` / `passage_end` in `bible.verses`' `'JHN.3.16'` form) rather than a chapter or stored text. Stored as a range so it can widen to two or three verses later without a migration; operations fills a single verse by default.
+5. **Signed-out End users see the verse only.** Reflection prompts, today's application and prayer are not in the anonymous response at all — `GET /devotion/today` returns the verse plus a `locked` list naming the withheld sections, so the client renders the sign-in invitation without ever holding the content.
+6. **Recording completion is an Encounter day, not "Amen".** `POST /api/v1/devotion/encounters` replaces `POST /api/v1/devotion/amen`. Product copy stays 「今日已與主相遇」.
+
+## Considered options
+
+| Option | Rejected | Why |
+| ------ | -------- | --- |
+| Keep Series/Plan tables, mark "Future", ship the calendar path alongside | Dormant model retained | A dormant second content path still has to be reasoned about on every change, and its presence invites re-resolving Today through enrollment. The PRD already said phase 1 doesn't have it; the schema should say so too |
+| Keep a single implicit "default series" so `seriesId` stays non-null | Fake series | Encodes a course that doesn't exist; the next engineer would build a series picker on top of it |
+| Return the full lesson to anonymous callers and blur it client-side | Client-side gate only | Once everything but the verse is gated, the whole day's authored content would ride the wire for any unauthenticated caller. The sign-in invitation would be a door with no wall behind it |
+| Server derives "today" from a device timezone the client sends | Timezone round-trip | The client already knows its local date; making the server re-derive it adds DST and travel edge cases for no gain (BR-02) |
+
+## Consequences
+
+- The `rooted-docs` PRD needs updating for the "Amen" → "Encounter" rename, the signed-out gate, and the weekly rhythm bar. **Tracked as a separate `rooted-docs` issue**, not part of this ADR; until it lands the PRD and this ADR disagree on those three points and the ADR wins.
+- `rooted_flutter`'s `CONTEXT.md` currently states anonymous reads work identically to signed-in reads (`CONTEXT.md` End user; `devotion_repository.dart`). That is now false for everything but the verse and must be corrected when the client work happens.
+- Nothing in `rooted-core-api` implements devotion yet — no models, no endpoints — so this removes documentation and client code, not backend code. The cost of this decision is paid almost entirely in `rooted_flutter`.
+- Reversing this means reintroducing per-user content resolution, which touches the content schema, the API surface and the client. Genuinely expensive; that is why it is written down.

--- a/docs/adr/0011-devotion-pool-schedule-and-per-locale-translations.md
+++ b/docs/adr/0011-devotion-pool-schedule-and-per-locale-translations.md
@@ -1,0 +1,44 @@
+# ADR 0011 — Devotion content is a pool scheduled onto dates, with one translation row per locale
+
+## Status
+
+Accepted (2026-09-08). Builds on ADR 0010, which established that a Daily lesson is identified by its calendar date.
+
+## Context
+
+ADR 0010 makes operations staff responsible for what every End user reads on a given day. That raises three questions the old series-based design never had to answer, because content and date were the same thing there (`lessons.day` inside a series):
+
+- Where does content live before it has a date, and can the same piece be used again on a different date?
+- Rooted's supported languages are rows in the existing system locale catalog (`public.system_locale`, seeded via `portal/cli/datas/locale_data.py`, manageable from the admin console), and translation lags authoring. What does a reader get on a day whose copy in their language isn't written yet?
+- What happens on a date nobody scheduled?
+
+The previous `rooted-docs` design answered the second with JSONB columns holding all locales in one row (`lessons.title`, `body`, `reflect`, `apply`, `pray`), which makes "which days are missing English?" an unindexable JSON scan.
+
+## Decision
+
+1. **Two concepts, not one.** A **Devotion** is one authored piece in the editorial pool — a verse reference plus reflection prompts, today's application and prayer — and exists with no date attached. A **Daily lesson** is a Devotion scheduled onto one calendar date. The schedule is its own table keyed uniquely by date.
+2. **A Devotion is authored and scheduled as one whole.** The four parts are written together and move together; there is no separate pool of reflection prompts or prayers to mix and match. They are written to answer each other.
+3. **One translation row per locale.** No JSONB multi-locale columns. This makes "which Devotions are missing a given language?" an ordinary indexed query, and lets per-locale editing permissions exist later.
+4. **Translation completeness is a publishing gate, not a runtime fallback.** A Devotion moves `draft` → `ready` only when **every active locale in the system locale catalog** has a translation row. There is no read-time fallback to another language: operations is blocked in the admin console before the gap can ever reach a reader.
+5. **The locale catalog is the single source of truth for which languages are required.** Devotion code holds no hardcoded language list. The admin console's existing multi-locale form (`TranslationTabsForm`) already renders one tab per catalog locale; the backend gate must check the same set, or activating a new language would silently produce publishable content that 404s for its readers.
+6. **There is no designated base locale for a Devotion.** The concept only existed to name a fallback target, and there is no fallback — every active locale is required, so none is privileged. Which tab the console opens first is a UI convenience (`defaultLocaleId`), not a domain rule. The catalog's own `is_default` flag governs unrelated admin-console behaviour and is deliberately not consulted here.
+7. **An unscheduled date is an error, never auto-filled.** `GET /devotion/today` returns 404 for a date with no scheduled Daily lesson. The admin console carries a forward-looking schedule calendar with unfilled dates flagged, plus a warning as the scheduled horizon runs short.
+8. **Content status stays two-state (`draft` → `ready`).** No review or approval workflow in this iteration.
+
+## Considered options
+
+| Option | Rejected | Why |
+| ------ | -------- | --- |
+| One row per calendar date holding the content inline | Date is the content's identity | Cheapest today, but a piece could never be rescheduled or reused, and drafts would have to squat on a date before anyone knew when they'd run |
+| JSONB column per field holding all locales | Multi-locale rows | Cannot answer "what is untranslated?" without scanning JSON; cannot grant an English editor write access to only the English text |
+| Read-time fallback to another language when a locale is missing | Silent fallback | Ships an experience nobody chose to ship, and removes the pressure that gets the translation done. Blocking at publish makes the gap visible to the person who can fix it |
+| Auto-fill an unscheduled date from unused pool content | Silent substitution | Turns a scheduling failure into an invisible one. Operations would never learn they had missed a day, and readers would get content chosen by a fallback rule rather than by a person |
+| Full `draft → in_review → approved → scheduled → published` workflow | Review workflow | With a small operations team, an unstaffed approval gate degrades into a rubber stamp. A schedule calendar with red gaps prevents the actual failure mode. `approved_by` can be added later without reshaping the model |
+
+## Consequences
+
+- Operations cannot publish a Devotion until every active locale is written. This is deliberate friction and will be felt; the alternative is readers hitting 404s or silently reading a language they did not choose.
+- **Activating a new locale in the catalog immediately raises the bar for every unpublished Devotion**, and leaves already-published ones incomplete for the new language. Deactivating is the escape hatch. This coupling is intentional — it is what stops the two sources of truth from drifting — but it means locale activation is a content-operations decision, not just a system setting.
+- Because the schedule is separate, the same Devotion can be scheduled onto more than one date over time. **Lesson notes and Encounter days therefore key on the calendar date, never on the Devotion** — a person's writing belongs to their day, not to the content, and a rescheduled Devotion must not resurface someone's two-year-old notes.
+- Scripture text is never copied into a Devotion or its translations. A Devotion holds a **Passage** reference; the text is resolved from the reader's chosen **Bible version** against `bible.verses` at read time.
+- The read path needs a locale. It comes from the request's `Accept-Language` header, consistent with ADR 0009 — language follows the device, and the anonymous read path has no account to consult.

--- a/docs/adr/0012-encounter-streak-store-longest-compute-current.md
+++ b/docs/adr/0012-encounter-streak-store-longest-compute-current.md
@@ -1,0 +1,35 @@
+# ADR 0012 — Store the longest Encounter streak; recompute the current one on every read
+
+## Status
+
+Accepted (2026-09-08).
+
+## Context
+
+The Today screen shows a weekly rhythm bar plus two numbers: the End user's **current** consecutive-day streak and their **longest ever**. The obvious implementation stores both as counters on a per-user row and updates them when an Encounter day is recorded.
+
+That is wrong for one of the two numbers, in a way that looks fine in every test.
+
+A streak has two ways to change: it grows when someone records an encounter, and it **breaks when time passes and they don't**. The first is a write. The second is not — nothing calls the backend on the day a person stops. A stored `current_streak` of `10` stays `10` for the six months someone is away, and is served as truth to anyone who reads it without checking the date.
+
+## Decision
+
+1. **`longest_streak` is stored.** It only ever increases, and only during a write. A stored value is always correct.
+2. **`current_streak` is stored as `(streak_length, last_encounter_date)` and validated at read.** On read, compare `last_encounter_date` against the reader's own local calendar date (BR-02, supplied by the client): if it is today or yesterday, the current streak is `streak_length`; otherwise it is `0`. The stored pair is a cache of a write, never an answer on its own.
+3. **The weekly bar is drawn from data, not from these numbers.** `GET /api/v1/devotion/rhythm?date=YYYY-MM-DD` returns `currentStreak`, `longestStreak` and a list of recently completed dates. The client slices that list into weeks using the End user's `week_start` preference (`sunday` | `monday`, default `sunday`).
+4. **Week start is an account Preference, not a device fact.** Unlike UI language (ADR 0009), which day a week begins on is a personal habit that should follow the person across devices.
+
+## Considered options
+
+| Option | Rejected | Why |
+| ------ | -------- | --- |
+| Store both counters, update on write | Naive denormalisation | Serves a stale `current_streak` for the entire duration of any absence — the exact case where the number matters and the exact case no test with a fixed clock will catch |
+| Store nothing; derive both from the encounter dates | Full recomputation | Correct, but computing "longest ever" means scanning a user's whole history on every Today open, forever. `longest_streak` is the one value that denormalises safely |
+| Nightly job that decays stale current streaks | Scheduled correction | Adds infrastructure to fix a problem that a date comparison at read solves for free, and leaves a window where the value is wrong |
+| Server derives "today" from the server clock | Server-side date | Rooted's servers are in North America and BR-02 defines the day as the device's local date. A server-clock comparison would break streaks for users near midnight |
+
+## Consequences
+
+- Reading the current streak requires the caller's local date. Every endpoint that returns it takes a `date` parameter; there is no "just read the column" path, and there should not be one.
+- The stored `streak_length` will be stale between an absence and the next sign of life. That is expected and safe — nothing reads it unvalidated. **Any future code that reads `streak_length` without comparing `last_encounter_date` to the reader's local date is a bug**, which is why this ADR exists.
+- Neither number is ever exposed to other members. The shepherd's pastoral view shows engagement signals, never comparable streak counts.


### PR DESCRIPTION
## Summary

Records the three decisions behind the Today redesign, and updates the domain glossary to match. Today becomes a calendar-dated **Daily lesson** chosen by the backend, replacing client-side resolution through a **Series** and **Plan enrollment**. Documentation only — no backend code exists for the devotion domain yet, so this ships the decisions before the implementation lands.

Spec: #47. Execution tickets: #48–#55 here, plus tickets in `rooted-portal-frontend`, `rooted_flutter` and `rooted-docs`.

## Type of change

- [ ] Bug fix
- [ ] New feature or API
- [x] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

**ADR 0010 — Today is a calendar Daily lesson; Series and Plan enrollment are removed.**
The `rooted-docs` PRD already overrode the product scope in August ([rooted-docs#5](https://github.com/rooted-faith/rooted-docs/issues/5)), but the model was left in place as "Future", so every devotion change still had to reason about a course path that will never run. This deletes the concepts rather than deferring them. Signed-out readers get the verse only, with the withheld sections **absent from the response** rather than gated client-side — otherwise the sign-in invitation is a door with no wall behind it.

**ADR 0011 — Devotion content is a pool scheduled onto dates, with one translation row per locale.**
Translation completeness is a **publishing gate**, not a read-time fallback: operations is blocked in the console before a gap can reach a reader. The required language set comes from the existing system locale catalog (`public.system_locale`) — devotion code holds no hardcoded language list, because the admin console's `TranslationTabsForm` already renders its tabs from that catalog, and a second source of truth would let a newly activated language ship content that 404s for its readers. An unscheduled date is a 404, never silently auto-filled.

**ADR 0012 — Store the longest Encounter streak; recompute the current one on every read.**
A streak breaks through the passage of time, and the passage of time triggers no write — so a stored `current_streak` stays correct in every test with a fixed clock and lies for the entire duration of a real absence. Only `longest_streak` denormalises safely.

**Naming.** `Amen` / `Walk day` become **Encounter day**. 「阿們」 is a response of assent rather than a statement of completion, and 「同行」 already names the shepherd's pastoral view in the PRD.

**Follow-ups, tracked separately:** the `rooted-docs` PRD contradicts ADR 0010 on the rename, the signed-out gate, and the weekly rhythm bar ([rooted-docs#11](https://github.com/rooted-faith/rooted-docs/issues/11)); `rooted_flutter`'s `CONTEXT.md` still claims anonymous reads work identically to signed-in reads ([rooted_flutter#37](https://github.com/rooted-faith/rooted_flutter/issues/37)).

## Testing

- [x] `uv run pytest` — 131 passed
- [x] `uv run ruff format` / `uv run ruff check --fix` — no changes to this branch's files (markdown only); 33 pre-existing unformatted Python files on `main` were left untouched rather than folded into a docs PR

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge