### PR TITLE
feat(auth): add end-user Apple sign-in

### DIFF
--- a/example.env
+++ b/example.env
@@ -42,10 +42,12 @@ GOOGLE_ADMIN_CLIENT_IDS=
 # End-user Google ID-token sign-in (ADR 0008) — comma-separated Client ID allowlist; empty disables Google app sign-in
 GOOGLE_APP_CLIENT_IDS=
 
+# Sign in with Apple App IDs / Services IDs accepted by the member API (comma-separated)
+APPLE_APP_CLIENT_IDS=
+
 # Push notifications (ADR 0007) — Firebase service-account credential, loaded per environment:
 # 1) FIREBASE_CREDENTIALS_PATH (if set) 2) env/firebase_credentials.json 3) /etc/secrets/firebase_credentials.json
 FIREBASE_CREDENTIALS_PATH=
 
 # Logging
 SENSITIVE_PARAMS=password,token,secret
-

--- a/portal/application/auth/app_apple_auth_service.py
+++ b/portal/application/auth/app_apple_auth_service.py
@@ -1,0 +1,84 @@
+"""End-user Sign in with Apple application service (ADR 0008)."""
+
+from portal.application.app.commands import ProvisionIdentityCommand
+from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.commands import AppAppleLoginCommand
+from portal.application.auth.member_login_service import MemberLoginService
+from portal.application.auth.results import MemberLoginResult, UserSensitive
+from portal.config import settings
+from portal.domain.app.ports import EndUserRepositoryPort
+from portal.domain.auth.entities import AppleIdentityClaims
+from portal.domain.auth.ports import AppleIdTokenVerifierPort, UserRepositoryPort
+from portal.exceptions.responses import UnauthorizedException
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+APPLE_PROVIDER_CODE = "apple"
+GENERIC_FAILURE_DETAIL = "Apple sign-in failed"
+
+
+def _is_end_user_eligible(user: UserSensitive) -> bool:
+    return user.verified and user.is_active
+
+
+class AppAppleAuthService:
+    """Resolve a verified Apple identity token to an End user, provisioning on first success."""
+
+    def __init__(
+        self,
+        provisioning_service: EndUserProvisioningService,
+        user_repository: UserRepositoryPort,
+        end_user_repository: EndUserRepositoryPort,
+        apple_id_token_verifier: AppleIdTokenVerifierPort,
+        member_login_service: MemberLoginService,
+    ):
+        self._provisioning_service = provisioning_service
+        self._user_repository = user_repository
+        self._end_user_repository = end_user_repository
+        self._verifier = apple_id_token_verifier
+        self._member_login_service = member_login_service
+
+    @distributed_trace()
+    async def login_with_apple(self, command: AppAppleLoginCommand) -> MemberLoginResult:
+        app_code = self._member_login_service.resolve_app_code()
+        client_ids = settings.apple_app_client_ids
+        if not client_ids or not await self._user_repository.identity_provider_is_active(APPLE_PROVIDER_CODE):
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        claims = await self._verifier.verify(command.id_token, audiences=client_ids)
+        if not claims:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        linked_user_id = await self._user_repository.get_user_id_by_identity_link(APPLE_PROVIDER_CODE, claims.subject)
+        if linked_user_id:
+            user = await self._user_repository.get_sensitive_by_id(linked_user_id)
+            if not user or not _is_end_user_eligible(user):
+                raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+            end_user = await self._end_user_repository.get_by_auth_user_id(user.id)
+            if not end_user:
+                raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+            return await self._member_login_service.complete_member_login(user=user, end_user_id=end_user.id, app_code=app_code)
+
+        if not claims.email_verified or not claims.email:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+        email = claims.email.strip().lower()
+        user = await self._user_repository.get_sensitive_by_email_without_profile(email)
+        if user is None:
+            return await self._provision_and_login(claims=claims, email=email, app_code=app_code)
+        if not _is_end_user_eligible(user):
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+        end_user = await self._end_user_repository.get_by_auth_user_id(user.id)
+        if not end_user:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+
+        await self._user_repository.upsert_identity_link(user.id, APPLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})
+        return await self._member_login_service.complete_member_login(user=user, end_user_id=end_user.id, app_code=app_code)
+
+    async def _provision_and_login(self, *, claims: AppleIdentityClaims, email: str, app_code: str) -> MemberLoginResult:
+        provisioned = await self._provisioning_service.provision(ProvisionIdentityCommand(email=email, password=None, create_end_user=True))
+        if provisioned.end_user_id is None:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+        user = await self._user_repository.get_sensitive_by_email_without_profile(email)
+        if not user:
+            raise UnauthorizedException(detail=GENERIC_FAILURE_DETAIL)
+        await self._user_repository.upsert_identity_link(user.id, APPLE_PROVIDER_CODE, claims.subject, additional_data={"email": claims.email})
+        return await self._member_login_service.complete_member_login(user=user, end_user_id=provisioned.end_user_id, app_code=app_code)

--- a/portal/application/auth/commands.py
+++ b/portal/application/auth/commands.py
@@ -57,6 +57,12 @@ class AppGoogleLoginCommand(BaseModel):
     id_token: str = Field(..., description="Google ID token from the app's Google sign-in client")
 
 
+class AppAppleLoginCommand(BaseModel):
+    """End-user Apple identity-token sign-in command (ADR 0008)."""
+
+    id_token: str = Field(..., description="Identity token from Sign in with Apple")
+
+
 class LogoutCommand(BaseModel):
     """Logout command."""
 

--- a/portal/config.py
+++ b/portal/config.py
@@ -129,6 +129,9 @@ class Configuration(BaseSettings):
     # [End-user Google ID-token sign-in — ADR 0008. Comma-separated Client ID allowlist; empty disables Google app sign-in.]
     GOOGLE_APP_CLIENT_IDS: str = os.getenv(key="GOOGLE_APP_CLIENT_IDS", default="")
 
+    # [End-user Apple identity-token sign-in — ADR 0008. Comma-separated App/Services ID allowlist.]
+    APPLE_APP_CLIENT_IDS: str = os.getenv(key="APPLE_APP_CLIENT_IDS", default="")
+
     # [Member web apps — Origin -> app_code for /api/v1 auth]
     MEMBER_WEB_APPS: str = os.getenv(key="MEMBER_WEB_APPS", default="rooted-app|http://localhost:5174")
 
@@ -248,6 +251,10 @@ class Configuration(BaseSettings):
     @property
     def google_app_client_ids(self) -> list[str]:
         return [client_id.strip() for client_id in self.GOOGLE_APP_CLIENT_IDS.split(",") if client_id.strip()]
+
+    @property
+    def apple_app_client_ids(self) -> list[str]:
+        return [client_id.strip() for client_id in self.APPLE_APP_CLIENT_IDS.split(",") if client_id.strip()]
 
 
 @lru_cache

--- a/portal/containers/__init__.py
+++ b/portal/containers/__init__.py
@@ -55,6 +55,7 @@ class RootContainer(containers.DeclarativeContainer):
     end_user_provisioning_service = app.end_user_provisioning_service
     end_user_service = app.end_user_service
     app_auth_service = app.app_auth_service
+    app_apple_auth_service = app.app_apple_auth_service
     app_google_auth_service = app.app_google_auth_service
     push_service = app.push_service
 

--- a/portal/containers/app.py
+++ b/portal/containers/app.py
@@ -6,6 +6,7 @@ from dependency_injector import containers, providers
 
 from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
 from portal.application.app.end_user_service import EndUserService
+from portal.application.auth.app_apple_auth_service import AppAppleAuthService
 from portal.application.auth.app_auth_service import AppAuthService
 from portal.application.auth.app_google_auth_service import AppGoogleAuthService
 from portal.application.auth.member_login_service import MemberLoginService
@@ -82,5 +83,13 @@ class AppContainer(containers.DeclarativeContainer):
         user_repository=user_repository,
         end_user_repository=end_user_repository,
         google_id_token_verifier=core.google_id_token_verifier,
+        member_login_service=member_login_service,
+    )
+    app_apple_auth_service = providers.Factory(
+        AppAppleAuthService,
+        provisioning_service=end_user_provisioning_service,
+        user_repository=user_repository,
+        end_user_repository=end_user_repository,
+        apple_id_token_verifier=core.apple_id_token_verifier,
         member_login_service=member_login_service,
     )

--- a/portal/containers/core.py
+++ b/portal/containers/core.py
@@ -7,6 +7,7 @@ from dependency_injector import containers, providers
 from portal.config import settings
 from portal.libs.database import PostgresConnection, RedisPool, Session
 from portal.libs.database.session_proxy import SessionProxy
+from portal.providers.apple_id_token_verifier import AppleIdTokenVerifier
 from portal.providers.firebase_push_gateway import FirebasePushGateway
 from portal.providers.google_id_token_verifier import GoogleIdTokenVerifier
 from portal.providers.jwt_provider import JWTProvider
@@ -34,4 +35,5 @@ class CoreContainer(containers.DeclarativeContainer):
     password_provider = providers.Singleton(PasswordProvider)
     refresh_token_provider = providers.Factory(RefreshTokenProvider, session=request_session)
     google_id_token_verifier = providers.Singleton(GoogleIdTokenVerifier)
+    apple_id_token_verifier = providers.Singleton(AppleIdTokenVerifier)
     push_gateway = providers.Singleton(FirebasePushGateway, credentials_dict=config.FIREBASE_CREDENTIALS)

--- a/portal/domain/auth/entities.py
+++ b/portal/domain/auth/entities.py
@@ -35,3 +35,12 @@ class GoogleIdentityClaims(BaseModel):
     email: Optional[str] = Field(default=None, description="Email claim as asserted by Google")
     email_verified: bool = Field(default=False, description="Whether Google verified the email claim")
     audience: str = Field(..., description="Token audience (aud) — the Client ID the token was issued for")
+
+
+class AppleIdentityClaims(BaseModel):
+    """Verified Apple identity-token claims relevant to End-user sign-in (ADR 0008)."""
+
+    subject: str = Field(..., description="Apple account stable subject (sub)")
+    email: Optional[str] = Field(default=None, description="Email claim as asserted by Apple")
+    email_verified: bool = Field(default=False, description="Whether Apple verified the email claim")
+    audience: str = Field(..., description="Token audience (aud) — the app Client ID or Services ID")

--- a/portal/domain/auth/ports.py
+++ b/portal/domain/auth/ports.py
@@ -6,7 +6,7 @@ from typing import Any, Optional, Protocol
 from uuid import UUID
 
 from portal.application.auth.results import UserDetail, UserSensitive
-from portal.domain.auth.entities import GoogleIdentityClaims
+from portal.domain.auth.entities import AppleIdentityClaims, GoogleIdentityClaims
 
 
 class UserRepositoryPort(Protocol):
@@ -86,4 +86,12 @@ class GoogleIdTokenVerifierPort(Protocol):
 
     async def verify(self, id_token: str, audiences: list[str]) -> Optional[GoogleIdentityClaims]:
         """Return verified claims, or None when the token is invalid, expired, or not issued for one of `audiences`."""
+        ...
+
+
+class AppleIdTokenVerifierPort(Protocol):
+    """Verify an Apple-issued identity token per ADR 0008."""
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[AppleIdentityClaims]:
+        """Return verified claims, or None when signature, issuer, expiry, or audience is invalid."""
         ...

--- a/portal/providers/apple_id_token_verifier.py
+++ b/portal/providers/apple_id_token_verifier.py
@@ -1,0 +1,39 @@
+"""Sign in with Apple identity-token verification (ADR 0008)."""
+
+from typing import Optional
+
+import jwt
+
+from portal.domain.auth.entities import AppleIdentityClaims
+from portal.libs.logger import logger
+from portal.libs.tracing.distributed_trace import distributed_trace
+
+APPLE_JWKS_URL = "https://appleid.apple.com/auth/keys"
+APPLE_ISSUER = "https://appleid.apple.com"
+
+
+class AppleIdTokenVerifier:
+    """Verify Apple RS256 tokens against Apple's published signing keys."""
+
+    def __init__(self):
+        self._jwk_client = jwt.PyJWKClient(APPLE_JWKS_URL)
+
+    @distributed_trace()
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[AppleIdentityClaims]:
+        if not id_token or not audiences:
+            return None
+        try:
+            signing_key = self._jwk_client.get_signing_key_from_jwt(id_token)
+            claims = jwt.decode(id_token, signing_key.key, algorithms=["RS256"], audience=audiences, issuer=APPLE_ISSUER)
+        except jwt.PyJWTError as error:
+            logger.warning(f"Apple identity token verification failed: {error}")
+            return None
+
+        subject = claims.get("sub")
+        audience = claims.get("aud")
+        if not subject or not audience:
+            return None
+        email_verified = claims.get("email_verified")
+        return AppleIdentityClaims(
+            subject=subject, email=claims.get("email"), email_verified=email_verified is True or email_verified == "true", audience=audience
+        )

--- a/portal/routers/apis/v1/auth.py
+++ b/portal/routers/apis/v1/auth.py
@@ -5,15 +5,30 @@ App (End user) authentication HTTP routes.
 from dependency_injector.wiring import Provide, inject
 from fastapi import Depends, status
 
+from portal.application.auth.app_apple_auth_service import AppAppleAuthService
 from portal.application.auth.app_auth_service import AppAuthService
 from portal.application.auth.app_google_auth_service import AppGoogleAuthService
-from portal.application.auth.commands import AppGoogleLoginCommand, AppOtpRequestCommand, AppOtpVerifyCommand, LogoutCommand, RefreshTokenCommand
+from portal.application.auth.commands import (
+    AppAppleLoginCommand,
+    AppGoogleLoginCommand,
+    AppOtpRequestCommand,
+    AppOtpVerifyCommand,
+    LogoutCommand,
+    RefreshTokenCommand,
+)
 from portal.application.auth.mappers import member_login_result_to_api, otp_request_result_to_api, token_result_to_api
 from portal.application.auth.refresh_token_service import RefreshTokenService
 from portal.container import Container
 from portal.libs.depends.rate_limiters import WRITE_RATE_LIMITERS
 from portal.routers.auth_router import AuthRouter
-from portal.serializers.apis.v1.auth import MemberGoogleLoginRequest, MemberLoginResponse, MemberOtpRequest, MemberOtpRequestResponse, MemberOtpVerifyRequest
+from portal.serializers.apis.v1.auth import (
+    MemberAppleLoginRequest,
+    MemberGoogleLoginRequest,
+    MemberLoginResponse,
+    MemberOtpRequest,
+    MemberOtpRequestResponse,
+    MemberOtpVerifyRequest,
+)
 from portal.serializers.mixins import LogoutRequest, LogoutResponse, RefreshTokenRequest, TokenResponse
 
 router: AuthRouter = AuthRouter()
@@ -70,6 +85,23 @@ async def app_verify_otp(body: MemberOtpVerifyRequest, app_auth_service: AppAuth
 @inject
 async def app_google_login(body: MemberGoogleLoginRequest, app_google_auth_service: AppGoogleAuthService = Depends(Provide[Container.app_google_auth_service])):
     result = await app_google_auth_service.login_with_google(AppGoogleLoginCommand(id_token=body.id_token))
+    return member_login_result_to_api(result)
+
+
+@router.post(
+    "/apple",
+    response_model=MemberLoginResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_200_OK,
+    require_auth=False,
+    dependencies=[*WRITE_RATE_LIMITERS],
+    operation_id="member_apple_login",
+    summary="Sign in with Apple",
+    description="Resolve a verified Apple identity token to an End user, provisioning the account on first success. Every rejection returns the same generic 401.",
+)
+@inject
+async def app_apple_login(body: MemberAppleLoginRequest, app_apple_auth_service: AppAppleAuthService = Depends(Provide[Container.app_apple_auth_service])):
+    result = await app_apple_auth_service.login_with_apple(AppAppleLoginCommand(id_token=body.id_token))
     return member_login_result_to_api(result)
 
 

--- a/portal/serializers/apis/v1/auth.py
+++ b/portal/serializers/apis/v1/auth.py
@@ -31,6 +31,12 @@ class MemberGoogleLoginRequest(BaseModel):
     id_token: str = Field(..., description="Google ID token from the app's Google sign-in client")
 
 
+class MemberAppleLoginRequest(BaseModel):
+    """End-user Sign in with Apple request body (ADR 0008)."""
+
+    id_token: str = Field(..., description="Identity token from Sign in with Apple")
+
+
 class MemberOtpRequestResponse(BaseModel):
     """Anti-enumeration acknowledgement."""
 

--- a/tests/application/auth/test_app_apple_auth_service.py
+++ b/tests/application/auth/test_app_apple_auth_service.py
@@ -1,0 +1,135 @@
+"""Application-service seam for End-user Apple identity-token sign-in."""
+
+from typing import Optional
+
+import pytest
+
+from portal.application.app.end_user_provisioning_service import EndUserProvisioningService
+from portal.application.auth.app_apple_auth_service import GENERIC_FAILURE_DETAIL, AppAppleAuthService
+from portal.application.auth.commands import AppAppleLoginCommand
+from portal.application.auth.member_login_service import MemberLoginService
+from portal.application.auth.results import MemberLoginResult
+from portal.domain.auth.entities import AppleIdentityClaims
+from portal.exceptions.responses import UnauthorizedException
+from tests.application.auth.test_app_google_auth_service import (
+    StubEndUserRepository,
+    StubJwtProvider,
+    StubMemberRefreshAppBindingProvider,
+    StubMemberWebAppRegistry,
+    StubPasswordProvider,
+    StubPreferencesRepository,
+    StubRefreshTokenProvider,
+    StubUserRepository,
+)
+
+ALLOWED_CLIENT_IDS = ["com.rooted.app"]
+
+
+class StubAppleIdTokenVerifier:
+    def __init__(self):
+        self.claims_by_token: dict[str, AppleIdentityClaims] = {}
+
+    def register(self, token: str, claims: AppleIdentityClaims) -> None:
+        self.claims_by_token[token] = claims
+
+    async def verify(self, id_token: str, audiences: list[str]) -> Optional[AppleIdentityClaims]:
+        claims = self.claims_by_token.get(id_token)
+        if not claims or claims.audience not in audiences:
+            return None
+        return claims
+
+
+def _build_service(monkeypatch: pytest.MonkeyPatch, client_ids: list[str] = ALLOWED_CLIENT_IDS):
+    from portal.config import settings
+
+    monkeypatch.setattr(settings, "APPLE_APP_CLIENT_IDS", ",".join(client_ids))
+    user_repo = StubUserRepository()
+    user_repo.apple_provider_active = True
+    original_provider_check = user_repo.identity_provider_is_active
+
+    async def provider_is_active(code: str) -> bool:
+        if code == "apple":
+            return user_repo.apple_provider_active
+        return await original_provider_check(code)
+
+    user_repo.identity_provider_is_active = provider_is_active
+    end_user_repo = StubEndUserRepository()
+    prefs_repo = StubPreferencesRepository()
+    verifier = StubAppleIdTokenVerifier()
+    provisioning = EndUserProvisioningService(user_repo, end_user_repo, prefs_repo, StubPasswordProvider())
+    login = MemberLoginService(
+        user_repo, end_user_repo, prefs_repo, StubJwtProvider(), StubRefreshTokenProvider(), StubMemberRefreshAppBindingProvider(), StubMemberWebAppRegistry()
+    )
+    service = AppAppleAuthService(provisioning, user_repo, end_user_repo, verifier, login)
+    return service, user_repo, end_user_repo, prefs_repo, verifier
+
+
+def _claims(subject="apple-sub-1", email="jay@example.com", email_verified=True, audience="com.rooted.app"):
+    return AppleIdentityClaims(subject=subject, email=email, email_verified=email_verified, audience=audience)
+
+
+@pytest.mark.asyncio
+async def test_first_success_provisions_a_brand_new_account_and_links_it(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, prefs_repo, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims(email="Jay@Example.com"))
+
+    result = await service.login_with_apple(AppAppleLoginCommand(id_token="token-1"))
+
+    assert isinstance(result, MemberLoginResult)
+    credential = user_repo.by_email["jay@example.com"]
+    end_user = end_user_repo.by_auth_user_id[credential.id]
+    assert result.member.id == end_user.id
+    assert prefs_repo.by_user_id[end_user.id].display_name == "jay"
+    assert user_repo.link_calls == [
+        {"user_id": credential.id, "provider": "apple", "provider_subject": "apple-sub-1", "additional_data": {"email": "Jay@Example.com"}}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_existing_identity_link_resolves_before_email_match(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    verifier.register("token-1", _claims())
+    first = await service.login_with_apple(AppAppleLoginCommand(id_token="token-1"))
+    user_repo.by_email.clear()
+
+    verifier.register("token-2", _claims(email=None, email_verified=False))
+    second = await service.login_with_apple(AppAppleLoginCommand(id_token="token-2"))
+
+    assert second.member.id == first.member.id
+    assert len(end_user_repo.by_auth_user_id) == 1
+    assert len(user_repo.link_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_verified_email_matches_existing_end_user_and_upserts_link(monkeypatch: pytest.MonkeyPatch):
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch)
+    credential = user_repo.seed_credential(email="jay@example.com")
+    end_user = end_user_repo.seed(credential.id)
+    verifier.register("token-1", _claims(email="JAY@example.com"))
+
+    result = await service.login_with_apple(AppAppleLoginCommand(id_token="token-1"))
+
+    assert result.member.id == end_user.id
+    assert user_repo.link_calls[0]["provider"] == "apple"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["inactive_provider", "no_audience", "invalid_token", "unverified_email", "inactive_user", "admin_only"])
+async def test_every_rejection_uses_the_same_generic_failure(monkeypatch: pytest.MonkeyPatch, failure: str):
+    client_ids = [] if failure == "no_audience" else ALLOWED_CLIENT_IDS
+    service, user_repo, end_user_repo, _prefs, verifier = _build_service(monkeypatch, client_ids)
+    claims = _claims(email_verified=failure != "unverified_email")
+    if failure != "invalid_token":
+        verifier.register("token-1", claims)
+    if failure == "inactive_provider":
+        user_repo.apple_provider_active = False
+    if failure == "inactive_user":
+        credential = user_repo.seed_credential(email=claims.email, is_active=False)
+        end_user_repo.seed(credential.id)
+    if failure == "admin_only":
+        user_repo.seed_credential(email=claims.email, is_admin=True, has_admin_profile=True)
+
+    with pytest.raises(UnauthorizedException) as exc_info:
+        await service.login_with_apple(AppAppleLoginCommand(id_token="token-1"))
+
+    assert exc_info.value.detail == GENERIC_FAILURE_DETAIL

--- a/tests/providers/test_apple_id_token_verifier.py
+++ b/tests/providers/test_apple_id_token_verifier.py
@@ -1,0 +1,30 @@
+from unittest.mock import Mock
+
+import jwt
+import pytest
+
+from portal.providers.apple_id_token_verifier import APPLE_ISSUER, AppleIdTokenVerifier
+
+
+@pytest.mark.asyncio
+async def test_verifies_signature_issuer_audience_and_expiry(monkeypatch: pytest.MonkeyPatch):
+    verifier = AppleIdTokenVerifier()
+    verifier._jwk_client.get_signing_key_from_jwt = Mock(return_value=Mock(key="public-key"))
+    decode = Mock(return_value={"sub": "apple-sub", "email": "jay@example.com", "email_verified": "true", "aud": "com.rooted.app"})
+    monkeypatch.setattr(jwt, "decode", decode)
+
+    claims = await verifier.verify("identity-token", ["com.rooted.app"])
+
+    assert claims is not None
+    assert claims.email_verified is True
+    decode.assert_called_once_with("identity-token", "public-key", algorithms=["RS256"], audience=["com.rooted.app"], issuer=APPLE_ISSUER)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("error", [jwt.InvalidSignatureError(), jwt.InvalidIssuerError(), jwt.InvalidAudienceError(), jwt.ExpiredSignatureError()])
+async def test_invalid_signature_issuer_audience_or_expiry_is_rejected(monkeypatch: pytest.MonkeyPatch, error: jwt.PyJWTError):
+    verifier = AppleIdTokenVerifier()
+    verifier._jwk_client.get_signing_key_from_jwt = Mock(return_value=Mock(key="public-key"))
+    monkeypatch.setattr(jwt, "decode", Mock(side_effect=error))
+
+    assert await verifier.verify("invalid-token", ["com.rooted.app"]) is None

--- a/tests/routers/apis/v1/test_auth.py
+++ b/tests/routers/apis/v1/test_auth.py
@@ -19,3 +19,8 @@ def test_end_user_password_register_and_login_routes_are_unreachable() -> None:
 
 def test_admin_password_login_route_remains_available() -> None:
     assert "/login" in _post_paths(admin_auth_router)
+
+
+def test_end_user_apple_login_route_is_available_without_an_admin_equivalent() -> None:
+    assert "/apple" in _post_paths(app_auth_router)
+    assert "/apple" not in _post_paths(admin_auth_router)


### PR DESCRIPTION
## Summary

Add fully live Sign in with Apple support for End users, including Apple identity-token verification, existing identity-link resolution, verified-email account matching, first-success provisioning, and the member API route.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Verifies Apple RS256 identity tokens against Apple's published JWKS with issuer, audience, signature, and expiry validation.
- Resolves existing Apple identity links before requiring email, supporting returning users when Apple omits email on later tokens.
- Uses the same generic authentication failure detail for all rejection paths.
- Adds only the End-user route; no Admin Apple sign-in route or rollout feature flag is introduced.
- Configures accepted Apple App IDs / Services IDs through `APPLE_APP_CLIENT_IDS`.

## Testing

- [x] `uv run ruff format --check <changed Python files>`
- [x] `uv run ruff check <changed Python files>`
- [x] `uv run pytest -q` — 149 passed

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Closes #40
