### PR TITLE
feat(devotion): add signed-in and past-date reads

### DIFF
--- a/portal/application/devotion/devotion_service.py
+++ b/portal/application/devotion/devotion_service.py
@@ -2,7 +2,7 @@ from datetime import date
 from uuid import UUID
 
 from portal.domain.devotion.constants import DevotionErrorCode
-from portal.domain.devotion.entities import AnonymousDailyLesson
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson
 from portal.domain.devotion.ports import DevotionRepositoryPort
 from portal.exceptions.responses import NotFoundException
 from portal.libs.tracing.distributed_trace import distributed_trace
@@ -13,8 +13,10 @@ class DevotionService:
         self._repository = devotion_repository
 
     @distributed_trace()
-    async def get_anonymous_today(self, lesson_date: date, locale_id: UUID | None, locale_code: str | None) -> AnonymousDailyLesson:
-        lesson = await self._repository.fetch_anonymous_daily_lesson(lesson_date, locale_id, locale_code)
+    async def get_daily_lesson(
+        self, lesson_date: date, locale_id: UUID | None, locale_code: str | None, include_authored_sections: bool
+    ) -> AnonymousDailyLesson | DailyLesson:
+        lesson = await self._repository.fetch_daily_lesson(lesson_date, locale_id, locale_code, include_authored_sections)
         if lesson is not None:
             return lesson
         if not await self._repository.daily_lesson_exists(lesson_date):

--- a/portal/application/devotion/mappers.py
+++ b/portal/application/devotion/mappers.py
@@ -1,6 +1,19 @@
-from portal.domain.devotion.entities import AnonymousDailyLesson
-from portal.serializers.apis.v1.devotion import AnonymousDailyLessonResponse, PassageResponse
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson
+from portal.serializers.apis.v1.devotion import AnonymousDailyLessonResponse, DailyLessonResponse, PassageResponse
 
 
 def anonymous_daily_lesson_to_api(result: AnonymousDailyLesson) -> AnonymousDailyLessonResponse:
     return AnonymousDailyLessonResponse(date=result.date, passage=PassageResponse(**result.passage.model_dump()), locked=result.locked)
+
+
+def daily_lesson_to_api(result: AnonymousDailyLesson | DailyLesson) -> AnonymousDailyLessonResponse | DailyLessonResponse:
+    if isinstance(result, DailyLesson):
+        return DailyLessonResponse(
+            date=result.date,
+            passage=PassageResponse(**result.passage.model_dump()),
+            reflect=result.reflect,
+            apply=result.apply,
+            pray=result.pray,
+            locked=result.locked,
+        )
+    return anonymous_daily_lesson_to_api(result)

--- a/portal/domain/devotion/entities.py
+++ b/portal/domain/devotion/entities.py
@@ -14,3 +14,12 @@ class AnonymousDailyLesson(BaseModel):
     date: date
     passage: Passage
     locked: list[str] = Field(default_factory=lambda: ["reflect", "apply", "pray", "note"])
+
+
+class DailyLesson(BaseModel):
+    date: date
+    passage: Passage
+    reflect: list[str] = Field(default_factory=list)
+    apply: str
+    pray: str
+    locked: list[str] = Field(default_factory=list)

--- a/portal/domain/devotion/ports.py
+++ b/portal/domain/devotion/ports.py
@@ -2,10 +2,12 @@ from datetime import date
 from typing import Protocol
 from uuid import UUID
 
-from portal.domain.devotion.entities import AnonymousDailyLesson
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson
 
 
 class DevotionRepositoryPort(Protocol):
-    async def fetch_anonymous_daily_lesson(self, lesson_date: date, locale_id: UUID | None, locale_code: str | None) -> AnonymousDailyLesson | None: ...
+    async def fetch_daily_lesson(
+        self, lesson_date: date, locale_id: UUID | None, locale_code: str | None, include_authored_sections: bool
+    ) -> AnonymousDailyLesson | DailyLesson | None: ...
 
     async def daily_lesson_exists(self, lesson_date: date) -> bool: ...

--- a/portal/infrastructure/persistence/repositories/devotion/devotion_repository.py
+++ b/portal/infrastructure/persistence/repositories/devotion/devotion_repository.py
@@ -3,7 +3,7 @@ from uuid import UUID
 
 import sqlalchemy as sa
 
-from portal.domain.devotion.entities import AnonymousDailyLesson, Passage
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson, Passage
 from portal.libs.database import Session
 from portal.models import BibleBook, BibleVerse, BibleVersion, Devotion, DevotionDailyLessonSchedule, DevotionTranslation
 
@@ -16,13 +16,18 @@ class DevotionRepository:
         schedule_id = await self._session.select(DevotionDailyLessonSchedule.id).where(DevotionDailyLessonSchedule.date == lesson_date).fetchval()
         return schedule_id is not None
 
-    async def fetch_anonymous_daily_lesson(self, lesson_date: date, locale_id: UUID | None, locale_code: str | None) -> AnonymousDailyLesson | None:
+    async def fetch_daily_lesson(
+        self, lesson_date: date, locale_id: UUID | None, locale_code: str | None, include_authored_sections: bool
+    ) -> AnonymousDailyLesson | DailyLesson | None:
         if locale_id is None or locale_code is None:
             return None
 
         language = locale_code.split("-", maxsplit=1)[0]
+        selected_columns = [Devotion.passage_start, Devotion.passage_end]
+        if include_authored_sections:
+            selected_columns.extend([DevotionTranslation.reflect, DevotionTranslation.apply, DevotionTranslation.pray])
         scheduled_passage = await (
-            self._session.select(Devotion.passage_start, Devotion.passage_end)
+            self._session.select(*selected_columns)
             .join(DevotionDailyLessonSchedule, DevotionDailyLessonSchedule.devotion_id == Devotion.id)
             .join(DevotionTranslation, DevotionTranslation.devotion_id == Devotion.id)
             .where(DevotionDailyLessonSchedule.date == lesson_date)
@@ -67,12 +72,14 @@ class DevotionRepository:
         verse_ref = f"{first['book_name']} {first['chapter']}:{first['verse']}"
         if (last["chapter"], last["verse"]) != (first["chapter"], first["verse"]):
             verse_ref += f"–{last['chapter']}:{last['verse']}"
-        return AnonymousDailyLesson(
-            date=lesson_date,
-            passage=Passage(
-                start=scheduled_passage["passage_start"], end=scheduled_passage["passage_end"], ref=verse_ref, verses=[row["content"] for row in verses]
-            ),
+        passage = Passage(
+            start=scheduled_passage["passage_start"], end=scheduled_passage["passage_end"], ref=verse_ref, verses=[row["content"] for row in verses]
         )
+        if include_authored_sections:
+            return DailyLesson(
+                date=lesson_date, passage=passage, reflect=scheduled_passage["reflect"], apply=scheduled_passage["apply"], pray=scheduled_passage["pray"]
+            )
+        return AnonymousDailyLesson(date=lesson_date, passage=passage)
 
     @staticmethod
     def _parse_passage_id(passage_id: str) -> tuple[str, int, int]:

--- a/portal/routers/apis/v1/devotion.py
+++ b/portal/routers/apis/v1/devotion.py
@@ -1,30 +1,21 @@
 from datetime import date
 
 from dependency_injector.wiring import Provide, inject
-from fastapi import APIRouter, Depends, Query
+from fastapi import Depends, Path, Query
 from starlette import status
 
 from portal.application.devotion.devotion_service import DevotionService
-from portal.application.devotion.mappers import anonymous_daily_lesson_to_api
+from portal.application.devotion.mappers import daily_lesson_to_api
 from portal.container import Container
 from portal.libs.contexts.request_context import get_request_context, get_resolved_locale_code, get_resolved_locale_id
-from portal.serializers.apis.v1.devotion import AnonymousDailyLessonResponse
+from portal.libs.contexts.user_context import get_user_context
+from portal.routers.auth_router import AuthRouter
+from portal.serializers.apis.v1.devotion import AnonymousDailyLessonResponse, DailyLessonResponse
 
-router = APIRouter()
+router: AuthRouter = AuthRouter(require_auth=False, optional_auth=True)
 
 
-@router.get(
-    path="/today",
-    response_model=AnonymousDailyLessonResponse,
-    response_model_by_alias=True,
-    status_code=status.HTTP_200_OK,
-    operation_id="get_anonymous_daily_lesson",
-    summary="Get today's anonymous Daily lesson",
-)
-@inject
-async def get_anonymous_daily_lesson(
-    date_: date = Query(alias="date"), devotion_service: DevotionService = Depends(Provide[Container.devotion_service])
-) -> AnonymousDailyLessonResponse:
+async def _read_daily_lesson(lesson_date: date, devotion_service: DevotionService) -> AnonymousDailyLessonResponse | DailyLessonResponse:
     locale_id = get_resolved_locale_id()
     locale_code = get_resolved_locale_code()
     request_context = get_request_context()
@@ -34,5 +25,38 @@ async def get_anonymous_daily_lesson(
         if "*" not in request_context.locale_candidates and resolved_language not in accepted_languages:
             locale_id = None
             locale_code = None
-    result = await devotion_service.get_anonymous_today(lesson_date=date_, locale_id=locale_id, locale_code=locale_code)
-    return anonymous_daily_lesson_to_api(result)
+    user_context = get_user_context()
+    result = await devotion_service.get_daily_lesson(
+        lesson_date=lesson_date, locale_id=locale_id, locale_code=locale_code, include_authored_sections=bool(user_context and user_context.user_id)
+    )
+    return daily_lesson_to_api(result)
+
+
+@router.get(
+    path="/today",
+    response_model=AnonymousDailyLessonResponse | DailyLessonResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_200_OK,
+    operation_id="get_anonymous_daily_lesson",
+    summary="Get today's Daily lesson",
+)
+@inject
+async def get_today_daily_lesson(
+    date_: date = Query(alias="date"), devotion_service: DevotionService = Depends(Provide[Container.devotion_service])
+) -> AnonymousDailyLessonResponse | DailyLessonResponse:
+    return await _read_daily_lesson(date_, devotion_service)
+
+
+@router.get(
+    path="/lessons/{date}",
+    response_model=AnonymousDailyLessonResponse | DailyLessonResponse,
+    response_model_by_alias=True,
+    status_code=status.HTTP_200_OK,
+    operation_id="get_daily_lesson",
+    summary="Get a Daily lesson by date",
+)
+@inject
+async def get_daily_lesson(
+    date_: date = Path(alias="date"), devotion_service: DevotionService = Depends(Provide[Container.devotion_service])
+) -> AnonymousDailyLessonResponse | DailyLessonResponse:
+    return await _read_daily_lesson(date_, devotion_service)

--- a/portal/serializers/apis/v1/devotion.py
+++ b/portal/serializers/apis/v1/devotion.py
@@ -14,3 +14,12 @@ class AnonymousDailyLessonResponse(BaseModel):
     date: date
     passage: PassageResponse
     locked: list[str] = Field(default_factory=list)
+
+
+class DailyLessonResponse(BaseModel):
+    date: date
+    passage: PassageResponse
+    reflect: list[str] = Field(default_factory=list)
+    apply: str
+    pray: str
+    locked: list[str] = Field(default_factory=list)

--- a/tests/application/devotion/test_devotion_service.py
+++ b/tests/application/devotion/test_devotion_service.py
@@ -4,7 +4,7 @@ import pytest
 
 from portal.application.devotion.devotion_service import DevotionService
 from portal.domain.devotion.constants import DevotionErrorCode
-from portal.domain.devotion.entities import AnonymousDailyLesson, Passage
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson, Passage
 from portal.exceptions.responses import NotFoundException
 
 
@@ -13,7 +13,7 @@ class StubDevotionRepository:
         self.lesson = lesson
         self.scheduled = scheduled
 
-    async def fetch_anonymous_daily_lesson(self, lesson_date, locale_id, locale_code):
+    async def fetch_daily_lesson(self, lesson_date, locale_id, locale_code, include_authored_sections):
         return self.lesson
 
     async def daily_lesson_exists(self, lesson_date):
@@ -21,33 +21,79 @@ class StubDevotionRepository:
 
 
 @pytest.mark.asyncio
-async def test_get_anonymous_today_returns_verse_and_locked_sections():
+async def test_get_daily_lesson_returns_verse_and_locked_sections_for_anonymous_end_user():
     lesson = AnonymousDailyLesson(
         date=date(2026, 9, 8), passage=Passage(start="JHN.3.16", end="JHN.3.16", ref="John 3:16", verses=["For God so loved the world"])
     )
     service = DevotionService(StubDevotionRepository(lesson=lesson))
 
-    result = await service.get_anonymous_today(date(2026, 9, 8), locale_id=None, locale_code="en")
+    result = await service.get_daily_lesson(date(2026, 9, 8), locale_id=None, locale_code="en", include_authored_sections=False)
 
     assert result == lesson
     assert result.locked == ["reflect", "apply", "pray", "note"]
 
 
 @pytest.mark.asyncio
-async def test_get_anonymous_today_raises_when_date_is_not_scheduled():
+async def test_get_daily_lesson_returns_all_authored_sections_for_signed_in_end_user():
+    lesson = DailyLesson(
+        date=date(2026, 9, 8),
+        passage=Passage(start="JHN.3.16", end="JHN.3.16", ref="John 3:16", verses=["For God so loved the world"]),
+        reflect=["Where do you see God's love today?", "Who can you love practically?"],
+        apply="Encourage one person today.",
+        pray="God, help me receive and share your love.",
+    )
+    service = DevotionService(StubDevotionRepository(lesson=lesson))
+
+    result = await service.get_daily_lesson(date(2026, 9, 8), locale_id=None, locale_code="en", include_authored_sections=True)
+
+    assert result == lesson
+    assert result.locked == []
+    assert result.reflect == ["Where do you see God's love today?", "Who can you love practically?"]
+    assert result.apply == "Encourage one person today."
+    assert result.pray == "God, help me receive and share your love."
+
+
+@pytest.mark.asyncio
+async def test_get_daily_lesson_anonymous_result_withholds_authored_sections():
+    lesson = AnonymousDailyLesson(
+        date=date(2026, 9, 7), passage=Passage(start="PSA.23.1", end="PSA.23.1", ref="Psalm 23:1", verses=["The Lord is my shepherd"])
+    )
+    service = DevotionService(StubDevotionRepository(lesson=lesson))
+
+    result = await service.get_daily_lesson(date(2026, 9, 7), locale_id=None, locale_code="en", include_authored_sections=False)
+
+    assert result == lesson
+    assert result.locked == ["reflect", "apply", "pray", "note"]
+    assert not hasattr(result, "reflect")
+    assert not hasattr(result, "apply")
+    assert not hasattr(result, "pray")
+
+
+@pytest.mark.asyncio
+async def test_get_daily_lesson_raises_when_date_is_not_scheduled():
     service = DevotionService(StubDevotionRepository(lesson=None, scheduled=False))
 
     with pytest.raises(NotFoundException) as error:
-        await service.get_anonymous_today(date(2026, 9, 9), locale_id=None, locale_code="en")
+        await service.get_daily_lesson(date(2026, 9, 9), locale_id=None, locale_code="en", include_authored_sections=False)
 
     assert error.value.error_code == DevotionErrorCode.DATE_NOT_SCHEDULED
 
 
 @pytest.mark.asyncio
-async def test_get_anonymous_today_raises_when_translation_is_missing():
+async def test_get_daily_lesson_raises_when_translation_is_missing_for_anonymous_end_user():
     service = DevotionService(StubDevotionRepository(lesson=None, scheduled=True))
 
     with pytest.raises(NotFoundException) as error:
-        await service.get_anonymous_today(date(2026, 9, 8), locale_id=None, locale_code="fr")
+        await service.get_daily_lesson(date(2026, 9, 8), locale_id=None, locale_code="fr", include_authored_sections=False)
+
+    assert error.value.error_code == DevotionErrorCode.TRANSLATION_NOT_FOUND
+
+
+@pytest.mark.asyncio
+async def test_get_daily_lesson_raises_when_translation_is_missing_for_signed_in_end_user():
+    service = DevotionService(StubDevotionRepository(lesson=None, scheduled=True))
+
+    with pytest.raises(NotFoundException) as error:
+        await service.get_daily_lesson(date(2026, 9, 8), locale_id=None, locale_code="fr", include_authored_sections=True)
 
     assert error.value.error_code == DevotionErrorCode.TRANSLATION_NOT_FOUND

--- a/tests/routers/apis/v1/test_devotion.py
+++ b/tests/routers/apis/v1/test_devotion.py
@@ -4,30 +4,49 @@ import pytest
 from fastapi.routing import APIRoute
 
 from portal.application.auth.results import HeaderInfo
-from portal.domain.devotion.entities import AnonymousDailyLesson, Passage
+from portal.domain.devotion.entities import AnonymousDailyLesson, DailyLesson, Passage
 from portal.libs.contexts.request_context import RequestContext
+from portal.libs.contexts.user_context import UserContext
 from portal.routers.apis.v1 import devotion as devotion_router_module
-from portal.routers.apis.v1.devotion import get_anonymous_daily_lesson, router
+from portal.routers.apis.v1.devotion import get_daily_lesson, get_today_daily_lesson, router
 
 
 class StubDevotionService:
-    async def get_anonymous_today(self, lesson_date, locale_id, locale_code):
+    async def get_daily_lesson(self, lesson_date, locale_id, locale_code, include_authored_sections):
         assert locale_code == "en"
+        if include_authored_sections:
+            return DailyLesson(
+                date=lesson_date,
+                passage=Passage(start="JHN.3.16", end="JHN.3.16", ref="John 3:16", verses=["Verse text"]),
+                reflect=["Reflect"],
+                apply="Apply",
+                pray="Pray",
+            )
         return AnonymousDailyLesson(date=lesson_date, passage=Passage(start="JHN.3.16", end="JHN.3.16", ref="John 3:16", verses=["Verse text"]))
+
+
+def stub_request_context(monkeypatch, user_context=None):
+    monkeypatch.setattr(devotion_router_module, "get_resolved_locale_id", lambda: None)
+    monkeypatch.setattr(devotion_router_module, "get_resolved_locale_code", lambda: "en")
+    monkeypatch.setattr(devotion_router_module, "get_request_context", lambda: None)
+    monkeypatch.setattr(devotion_router_module, "get_user_context", lambda: user_context)
 
 
 def test_devotion_today_route_is_available_as_get():
     routes = [route for route in router.routes if isinstance(route, APIRoute)]
     assert any(route.path == "/today" and "GET" in route.methods for route in routes)
+    assert any(route.path == "/lessons/{date}" and "GET" in route.methods for route in routes)
+    for route in routes:
+        auth_config = route.endpoint.__auth_config__
+        assert auth_config.require_auth is False
+        assert auth_config.optional_auth is True
 
 
 @pytest.mark.asyncio
 async def test_anonymous_today_response_omits_authored_sections(monkeypatch):
-    monkeypatch.setattr(devotion_router_module, "get_resolved_locale_id", lambda: None)
-    monkeypatch.setattr(devotion_router_module, "get_resolved_locale_code", lambda: "en")
-    monkeypatch.setattr(devotion_router_module, "get_request_context", lambda: None)
+    stub_request_context(monkeypatch)
 
-    response = await get_anonymous_daily_lesson(date_=date(2026, 9, 8), devotion_service=StubDevotionService())
+    response = await get_today_daily_lesson(date_=date(2026, 9, 8), devotion_service=StubDevotionService())
     payload = response.model_dump(mode="json", by_alias=True)
 
     assert payload["locked"] == ["reflect", "apply", "pray", "note"]
@@ -36,13 +55,52 @@ async def test_anonymous_today_response_omits_authored_sections(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_signed_in_today_response_includes_authored_sections(monkeypatch):
+    stub_request_context(monkeypatch, UserContext(user_id="11111111-1111-1111-1111-111111111111"))
+
+    response = await get_today_daily_lesson(date_=date(2026, 9, 8), devotion_service=StubDevotionService())
+    payload = response.model_dump(mode="json", by_alias=True)
+
+    assert payload["locked"] == []
+    assert payload["reflect"] == ["Reflect"]
+    assert payload["apply"] == "Apply"
+    assert payload["pray"] == "Pray"
+
+
+@pytest.mark.asyncio
+async def test_past_date_uses_same_anonymous_gating(monkeypatch):
+    stub_request_context(monkeypatch)
+
+    response = await get_daily_lesson(date_=date(2026, 9, 7), devotion_service=StubDevotionService())
+    payload = response.model_dump(mode="json", by_alias=True)
+
+    assert payload["date"] == "2026-09-07"
+    assert payload["locked"] == ["reflect", "apply", "pray", "note"]
+    assert not {"reflect", "apply", "pray"} & payload.keys()
+
+
+@pytest.mark.asyncio
+async def test_past_date_uses_same_signed_in_gating(monkeypatch):
+    stub_request_context(monkeypatch, UserContext(user_id="11111111-1111-1111-1111-111111111111"))
+
+    response = await get_daily_lesson(date_=date(2026, 9, 7), devotion_service=StubDevotionService())
+    payload = response.model_dump(mode="json", by_alias=True)
+
+    assert payload["date"] == "2026-09-07"
+    assert payload["locked"] == []
+    assert payload["reflect"] == ["Reflect"]
+    assert payload["apply"] == "Apply"
+    assert payload["pray"] == "Pray"
+
+
+@pytest.mark.asyncio
 async def test_unaccepted_default_locale_is_not_used_as_translation_fallback(monkeypatch):
     captured = {}
 
     class CapturingService(StubDevotionService):
-        async def get_anonymous_today(self, lesson_date, locale_id, locale_code):
+        async def get_daily_lesson(self, lesson_date, locale_id, locale_code, include_authored_sections):
             captured.update(locale_id=locale_id, locale_code=locale_code)
-            return await super().get_anonymous_today(lesson_date, locale_id, "en")
+            return await super().get_daily_lesson(lesson_date, locale_id, "en", include_authored_sections)
 
     monkeypatch.setattr(devotion_router_module, "get_resolved_locale_id", lambda: object())
     monkeypatch.setattr(devotion_router_module, "get_resolved_locale_code", lambda: "en")
@@ -50,6 +108,8 @@ async def test_unaccepted_default_locale_is_not_used_as_translation_fallback(mon
         devotion_router_module, "get_request_context", lambda: RequestContext(headers=HeaderInfo(), locale_candidates=["fr"], resolved_locale_code="en")
     )
 
-    await get_anonymous_daily_lesson(date_=date(2026, 9, 8), devotion_service=CapturingService())
+    monkeypatch.setattr(devotion_router_module, "get_user_context", lambda: None)
+
+    await get_today_daily_lesson(date_=date(2026, 9, 8), devotion_service=CapturingService())
 
     assert captured == {"locale_id": None, "locale_code": None}


### PR DESCRIPTION
## Summary

Return the complete authored Daily lesson to authenticated End users while preserving the verse-only anonymous response, and add date-addressable reads for revisiting past lessons.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Implementation notes

- Uses optional authentication on both devotion read routes.
- Keeps authored fields structurally absent for anonymous callers and reports them through `locked`.
- Applies the same locale, schedule, and translation-not-found behavior to Today and past dates.

## Testing

- [x] `uv run pytest` (172 passed)
- [x] `uv run ruff format <changed files>`
- [x] `uv run ruff check --fix <changed files>`

## Checklist

- [x] PR targets **`main`**
- [ ] CI green before merge

Closes #51