### PR TITLE
feat: import Bible index as empty verse shells (#73)

### DIFF
--- a/portal/application/bible/mappers.py
+++ b/portal/application/bible/mappers.py
@@ -43,7 +43,7 @@ def bible_chapter_to_api(result: BibleChapterResult) -> BibleChapterDetail:
         book_code=result.book_code,
         book_name=result.book_name,
         chapter=result.chapter,
-        verses=[BibleVerse(verse=item.verse, content=item.content) for item in result.verses],
+        verses=[BibleVerse(passage_id=item.passage_id, verse=item.verse, verse_end=item.verse_end, lines=item.lines) for item in result.verses],
     )
 
 

--- a/portal/cli/import_bible.py
+++ b/portal/cli/import_bible.py
@@ -1,9 +1,9 @@
 """
-Import Bible data from bible_data directory to database
+Import a Bible catalog and index from bible_data directory to database.
 """
+
 import asyncio
 import json
-import sqlite3
 import time
 from pathlib import Path
 from uuid import UUID
@@ -17,7 +17,7 @@ from portal.models import BibleBook, BibleVerse, BibleVersion
 
 async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
     """
-    Import Bible data from bible_data directory to database
+    Import Bible metadata, books, and empty verse shells from a dumped index.
 
     :param bible_id: Bible ID (e.g., '1392')
     :param data_dir: Directory containing bible data (default: 'bible_data')
@@ -29,15 +29,12 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
     meta_dir = bible_dir / "meta"
     bible_json_path = meta_dir / "bible.json"
     index_json_path = meta_dir / "index.json"
-    passages_db_path = bible_dir / "passages.db"
 
     # Check if files exist
     if not bible_json_path.exists():
         raise FileNotFoundError(f"Bible metadata not found: {bible_json_path}")
     if not index_json_path.exists():
         raise FileNotFoundError(f"Bible index not found: {index_json_path}")
-    if not passages_db_path.exists():
-        raise FileNotFoundError(f"Passages database not found: {passages_db_path}")
 
     try:
         # 1. Load and import Bible Version
@@ -50,7 +47,7 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
         if bible_meta.get("organization_id"):
             try:
                 organization_id = UUID(bible_meta["organization_id"])
-            except (ValueError, TypeError):
+            except ValueError, TypeError:
                 logger.warning(f"Invalid organization_id: {bible_meta.get('organization_id')}")
 
         click.echo(f"Importing Bible version: {bible_meta.get('localized_title', bible_meta.get('title'))}...")
@@ -91,11 +88,7 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
         await session.commit()
 
         # Get the version ID
-        version = await (
-            session.select(BibleVersion.id)
-            .where(BibleVersion.youversion_bible_id == str(bible_meta["id"]))
-            .fetchval()
-        )
+        version = await session.select(BibleVersion.id).where(BibleVersion.youversion_bible_id == str(bible_meta["id"])).fetchval()
         if not version:
             raise ValueError(f"Failed to get Bible version ID for {bible_meta['id']}")
 
@@ -156,12 +149,7 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
             )
 
             # Get the book ID
-            book = await (
-                session.select(BibleBook.id)
-                .where(BibleBook.bible_version_id == version)
-                .where(BibleBook.book_code == book_code)
-                .fetchval()
-            )
+            book = await session.select(BibleBook.id).where(BibleBook.bible_version_id == version).where(BibleBook.book_code == book_code).fetchval()
             if book:
                 book_id_map[book_code] = book
 
@@ -170,96 +158,51 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
         await session.commit()
         click.echo(f"Imported {len(book_id_map)} books")
 
-        # 3. Load and import Bible Verses
-        click.echo(f"Loading verses from {passages_db_path}...")
-        conn = sqlite3.connect(passages_db_path)
-        conn.row_factory = sqlite3.Row
-        cursor = conn.cursor()
-
-        # Count total verses
-        cursor.execute("SELECT COUNT(*) FROM verses")
-        total_verses = cursor.fetchone()[0]
-        click.echo(f"Found {total_verses} verses to import...")
-
-        # Fetch verses in batches
-        batch_size = 1000
-        cursor.execute("SELECT bible_id, book_id, chapter, verse, passage_id, data FROM verses ORDER BY book_id, chapter, verse")
-
+        # 3. Load and import empty Bible Verse shells from the index.
         imported_count = 0
-        batch = []
-
-        for row in cursor:
-            book_code = row["book_id"]
+        for book_data in books_data:
+            book_code = book_data["id"]
             book_id = book_id_map.get(book_code)
-            if not book_id:
-                logger.warning(f"Book not found for book_code: {book_code}, skipping verse {row['passage_id']}")
+            if book_id is None:
                 continue
 
-            # Parse verse content from JSON data
-            try:
-                verse_data = json.loads(row["data"])
-                content = verse_data.get("content", "")
-            except (json.JSONDecodeError, TypeError):
-                logger.warning(f"Failed to parse verse data for {row['passage_id']}")
-                continue
+            for chapter_data in book_data.get("chapters", []):
+                chapter_value = chapter_data.get("title", chapter_data.get("id"))
+                try:
+                    chapter = int(chapter_value)
+                except TypeError, ValueError:
+                    logger.warning(f"Invalid chapter in Bible index: {book_code}.{chapter_value}")
+                    continue
 
-            chapter = int(row["chapter"]) if row["chapter"] else None
-            verse = int(row["verse"]) if row["verse"] else None
+                for verse_data in chapter_data.get("verses", []):
+                    verse_value = verse_data.get("title", verse_data.get("id"))
+                    try:
+                        verse = int(verse_value)
+                    except TypeError, ValueError:
+                        logger.warning(f"Invalid verse in Bible index: {book_code}.{chapter}.{verse_value}")
+                        continue
 
-            if chapter is None or verse is None:
-                logger.warning(f"Invalid chapter/verse for {row['passage_id']}")
-                continue
-
-            batch.append({
-                "book_id": book_id,
-                "chapter": chapter,
-                "verse": verse,
-                "passage_id": row["passage_id"],
-                "content": content,
-            })
-
-            if len(batch) >= batch_size:
-                # Insert batch
-                for verse_data in batch:
+                    verse_shell = {
+                        "book_id": book_id,
+                        "chapter": chapter,
+                        "verse": verse,
+                        "verse_end": None,
+                        "passage_id": verse_data.get("passage_id", f"{book_code}.{chapter}.{verse}"),
+                        "lines": None,
+                        "search_text": None,
+                    }
                     await (
                         session.insert(BibleVerse)
-                        .values(**verse_data)
+                        .values(**verse_shell)
                         .on_conflict_do_update(
                             index_elements=["book_id", "passage_id"],
-                            set_={
-                                "chapter": verse_data["chapter"],
-                                "verse": verse_data["verse"],
-                                "content": verse_data["content"],
-                            },
+                            set_={"chapter": verse_shell["chapter"], "verse": verse_shell["verse"], "verse_end": None, "lines": None, "search_text": None},
                         )
                         .execute()
                     )
+                    imported_count += 1
 
-                await session.commit()
-                imported_count += len(batch)
-                click.echo(f"Imported {imported_count}/{total_verses} verses...")
-                batch = []
-
-        # Insert remaining batch
-        if batch:
-            for verse_data in batch:
-                await (
-                    session.insert(BibleVerse)
-                    .values(**verse_data)
-                    .on_conflict_do_update(
-                        index_elements=["book_id", "passage_id"],
-                        set_={
-                            "chapter": verse_data["chapter"],
-                            "verse": verse_data["verse"],
-                            "content": verse_data["content"],
-                        },
-                    )
-                    .execute()
-                )
-            await session.commit()
-            imported_count += len(batch)
-
-        conn.close()
+        await session.commit()
         click.echo(f"Successfully imported {imported_count} verses")
         click.echo(f"Bible data import completed for {bible_id}")
 
@@ -275,4 +218,3 @@ async def import_bible_data(bible_id: str, data_dir: str = "bible_data"):
 def import_bible_data_process(bible_id: str, data_dir: str = "bible_data"):
     """Synchronous entry point for importing Bible data"""
     asyncio.run(import_bible_data(bible_id=bible_id, data_dir=data_dir))
-

--- a/portal/cli/main.py
+++ b/portal/cli/main.py
@@ -40,11 +40,11 @@ def dump_bible_cmd(bible_id: str, out: str, daily_limit: int, sleep: float, time
 @click.option("--data-dir", default="bible_data", help="Bible data directory (default: bible_data)")
 def import_bible_cmd(bible_id: str, data_dir: str):
     """
-    Import Bible data from bible_data directory to database.
+    Import a Bible catalog and index from bible_data directory to database.
     This command imports:
     1. Bible version metadata from bible_data/{bible_id}/meta/bible.json
     2. Bible books from bible_data/{bible_id}/meta/index.json
-    3. Bible verses from bible_data/{bible_id}/passages.db
+    3. Empty Bible verse shells from bible_data/{bible_id}/meta/index.json
     """
     import_bible_data_process(bible_id=bible_id, data_dir=data_dir)
 

--- a/portal/domain/bible/entities.py
+++ b/portal/domain/bible/entities.py
@@ -2,6 +2,7 @@
 Bible domain read models (snake_case).
 """
 
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -38,7 +39,8 @@ class BibleVerse(BaseModel):
 
     passage_id: str = Field(...)
     verse: int = Field(...)
-    content: str = Field(...)
+    verse_end: int | None = Field(default=None)
+    lines: list[dict[str, Any]] | None = Field(default=None)
 
 
 class BibleChapter(BaseModel):

--- a/portal/infrastructure/persistence/repositories/bible/bible_repository.py
+++ b/portal/infrastructure/persistence/repositories/bible/bible_repository.py
@@ -81,7 +81,7 @@ class BibleRepository:
             return None
 
         verses: list[BibleVerse] = await (
-            self._session.select(BibleVerseModel.passage_id, BibleVerseModel.verse, BibleVerseModel.content)
+            self._session.select(BibleVerseModel.passage_id, BibleVerseModel.verse, BibleVerseModel.verse_end, BibleVerseModel.lines)
             .where(BibleVerseModel.book_id == book_id)
             .where(BibleVerseModel.chapter == chapter)
             .order_by(BibleVerseModel.verse)
@@ -100,35 +100,4 @@ class BibleRepository:
         )
 
     async def search_verses(self, q: str, bible_version_id: UUID | None, book_id: UUID | None, limit: int, offset: int) -> BibleSearchPage:
-        query = (
-            self._session.select(
-                BibleVersionModel.id.label("bible_version_id"),
-                BibleVersionModel.youversion_bible_id,
-                BibleVersionModel.localized_title.label("bible_title"),
-                BibleVerseModel.book_id,
-                BibleBookModel.book_code,
-                BibleBookModel.title.label("book_name"),
-                BibleVerseModel.chapter,
-                BibleVerseModel.verse,
-                BibleVerseModel.content,
-            )
-            .join(BibleBookModel, BibleVerseModel.book_id == BibleBookModel.id)
-            .join(BibleVersionModel, BibleBookModel.bible_version_id == BibleVersionModel.id)
-            .where(BibleVersionModel.is_active == True)  # noqa: E712
-            .where(BibleVerseModel.content.ilike(f"%{q}%"))
-        )
-
-        if bible_version_id:
-            query = query.where(BibleVersionModel.id == bible_version_id)
-        if book_id:
-            query = query.where(BibleVerseModel.book_id == book_id)
-
-        total = await query.count()
-        results: list[BibleSearchHit] = await (
-            query.order_by(BibleVersionModel.youversion_bible_id, BibleBookModel.sequence, BibleVerseModel.chapter, BibleVerseModel.verse)
-            .limit(limit)
-            .offset(offset)
-            .fetch(as_model=BibleSearchHit)
-        )
-
-        return BibleSearchPage(results=results or [], total=total, limit=limit, offset=offset)
+        return BibleSearchPage(results=[], total=0, limit=limit, offset=offset)

--- a/portal/serializers/admin/v1/bible.py
+++ b/portal/serializers/admin/v1/bible.py
@@ -1,5 +1,6 @@
 """Admin Bible response serializers."""
 
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer
@@ -47,7 +48,8 @@ class AdminBibleBookList(BaseModel):
 class AdminBibleVerse(BaseModel):
     passage_id: str = Field(..., serialization_alias="passageId")
     verse: int = Field(...)
-    content: str = Field(...)
+    verse_end: int | None = Field(default=None, serialization_alias="verseEnd")
+    lines: list[dict[str, Any]] | None = Field(default=None)
 
 
 class AdminBibleChapterDetail(BaseModel):

--- a/portal/serializers/apis/v1/bible.py
+++ b/portal/serializers/apis/v1/bible.py
@@ -2,6 +2,7 @@
 Member Bible API serializers (camelCase JSON via serialization_alias).
 """
 
+from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel, Field, field_serializer
@@ -47,8 +48,10 @@ class BibleBookList(BaseModel):
 
 
 class BibleVerse(BaseModel):
+    passage_id: str = Field(..., serialization_alias="passageId")
     verse: int = Field(...)
-    content: str = Field(...)
+    verse_end: int | None = Field(default=None, serialization_alias="verseEnd")
+    lines: list[dict[str, Any]] | None = Field(default=None)
 
 
 class BibleChapterDetail(BaseModel):

--- a/tests/application/bible/test_mappers.py
+++ b/tests/application/bible/test_mappers.py
@@ -1,0 +1,25 @@
+"""Tests for Bible API response mappings."""
+
+from uuid import uuid4
+
+from portal.application.bible.mappers import bible_chapter_to_admin_api, bible_chapter_to_api
+from portal.domain.bible.entities import BibleChapter, BibleVerse
+
+
+def test_chapter_mappers_expose_index_verse_shells_without_content() -> None:
+    chapter = BibleChapter(
+        bible_version_id=uuid4(),
+        youversion_bible_id="1392",
+        bible_title="當代譯本",
+        book_id=uuid4(),
+        book_code="GEN",
+        book_name="Genesis",
+        chapter=1,
+        verses=[BibleVerse(passage_id="GEN.1.1", verse=1, lines=None)],
+    )
+
+    member_verse = bible_chapter_to_api(chapter).model_dump(by_alias=True)["verses"]
+    admin_verse = bible_chapter_to_admin_api(chapter).model_dump(by_alias=True)["verses"]
+
+    assert member_verse == [{"passageId": "GEN.1.1", "verse": 1, "verseEnd": None, "lines": None}]
+    assert admin_verse == member_verse

--- a/tests/cli/test_import_bible.py
+++ b/tests/cli/test_import_bible.py
@@ -1,0 +1,113 @@
+"""Tests for importing a Bible catalog index without downloaded passages."""
+
+import json
+from pathlib import Path
+from uuid import UUID, uuid4
+
+import pytest
+
+from portal.cli import import_bible
+from portal.models import BibleBook, BibleVerse, BibleVersion
+
+
+class StubInsert:
+    def __init__(self, session: "StubSession", model) -> None:
+        self._session = session
+        self._model = model
+        self._values: dict = {}
+
+    def values(self, **values):
+        self._values = values
+        self._session.inserts.append((self._model, values))
+        return self
+
+    def on_conflict_do_update(self, **kwargs):
+        self._session.updates.append((self._model, kwargs["set_"]))
+        return self
+
+    async def execute(self) -> None:
+        return None
+
+
+class StubSelect:
+    def __init__(self, value: UUID) -> None:
+        self._value = value
+
+    def where(self, _condition):
+        return self
+
+    async def fetchval(self) -> UUID:
+        return self._value
+
+
+class StubSession:
+    def __init__(self, values: list[UUID]) -> None:
+        self._values = iter(values)
+        self.inserts: list[tuple[type, dict]] = []
+        self.updates: list[tuple[type, dict]] = []
+
+    def insert(self, model) -> StubInsert:
+        return StubInsert(self, model)
+
+    def select(self, _column) -> StubSelect:
+        return StubSelect(next(self._values))
+
+    async def commit(self) -> None:
+        return None
+
+    async def rollback(self) -> None:
+        return None
+
+    async def close(self) -> None:
+        return None
+
+
+class StubContainer:
+    def __init__(self, session: StubSession) -> None:
+        self._session = session
+
+    def db_session(self) -> StubSession:
+        return self._session
+
+
+@pytest.mark.asyncio
+async def test_import_bible_loads_index_as_empty_verse_shells_without_passages_database(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bible_id = "1392"
+    version_id = uuid4()
+    genesis_id = uuid4()
+    session = StubSession(values=[version_id, genesis_id])
+    meta_dir = tmp_path / bible_id / "meta"
+    meta_dir.mkdir(parents=True)
+    (meta_dir / "bible.json").write_text(
+        json.dumps(
+            {"id": bible_id, "abbreviation": "CCBT", "title": "Chinese Contemporary Bible", "localized_title": "當代譯本", "language_tag": "zh-Hant-TW"}
+        ),
+        encoding="utf-8",
+    )
+    (meta_dir / "index.json").write_text(
+        json.dumps(
+            {
+                "books": [
+                    {
+                        "id": "GEN",
+                        "title": "Genesis",
+                        "chapters": [{"id": "1", "verses": [{"id": "1", "passage_id": "GEN.1.1"}, {"id": "2", "passage_id": "GEN.1.2"}]}],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(import_bible, "Container", lambda: StubContainer(session))
+
+    await import_bible.import_bible_data(bible_id=bible_id, data_dir=str(tmp_path))
+
+    assert [model for model, _ in session.inserts] == [BibleVersion, BibleBook, BibleVerse, BibleVerse]
+    assert [values for model, values in session.inserts if model is BibleVerse] == [
+        {"book_id": genesis_id, "chapter": 1, "verse": 1, "verse_end": None, "passage_id": "GEN.1.1", "lines": None, "search_text": None},
+        {"book_id": genesis_id, "chapter": 1, "verse": 2, "verse_end": None, "passage_id": "GEN.1.2", "lines": None, "search_text": None},
+    ]
+    assert [values for model, values in session.updates if model is BibleVerse] == [
+        {"chapter": 1, "verse": 1, "verse_end": None, "lines": None, "search_text": None},
+        {"chapter": 1, "verse": 2, "verse_end": None, "lines": None, "search_text": None},
+    ]

--- a/tests/infrastructure/persistence/repositories/bible/test_bible_repository.py
+++ b/tests/infrastructure/persistence/repositories/bible/test_bible_repository.py
@@ -1,0 +1,22 @@
+"""Tests for BibleRepository."""
+
+import pytest
+
+from portal.infrastructure.persistence.repositories.bible.bible_repository import BibleRepository
+
+
+class FailingSession:
+    def __getattr__(self, name: str):
+        raise AssertionError(f"search must not access the database through {name}")
+
+
+@pytest.mark.asyncio
+async def test_search_verses_returns_an_empty_page_without_read_time_fill() -> None:
+    repository = BibleRepository(session=FailingSession())
+
+    page = await repository.search_verses(q="beginning", bible_version_id=None, book_id=None, limit=20, offset=0)
+
+    assert page.results == []
+    assert page.total == 0
+    assert page.limit == 20
+    assert page.offset == 0

--- a/tests/routers/admin/v1/content/test_bible.py
+++ b/tests/routers/admin/v1/content/test_bible.py
@@ -17,7 +17,7 @@ class StubBibleService:
             book_code="JHN",
             book_name="John",
             chapter=chapter,
-            verses=[BibleVerse(passage_id="JHN.3.16", verse=16, content="For God so loved the world")],
+            verses=[BibleVerse(passage_id="JHN.3.16", verse=16, lines=None)],
         )
 
 
@@ -40,4 +40,4 @@ def test_admin_bible_routes_require_admin_devotion_read_permission():
 async def test_admin_chapter_verses_include_passage_id():
     response = await get_bible_chapter(book_id=uuid4(), chapter=3, bible_service=StubBibleService())
 
-    assert response.model_dump(mode="json", by_alias=True)["verses"] == [{"passageId": "JHN.3.16", "verse": 16, "content": "For God so loved the world"}]
+    assert response.model_dump(mode="json", by_alias=True)["verses"] == [{"passageId": "JHN.3.16", "verse": 16, "verseEnd": None, "lines": None}]


### PR DESCRIPTION
## Summary

Import Bible metadata and its index without requiring `passages.db`, storing verse addresses as empty shells. Chapter APIs now return verse addresses and nullable `lines` without triggering YouVersion; search safely returns an empty page until read-time fill ships.

## Type of change

- [ ] Bug fix
- [x] New feature or API
- [ ] Documentation only
- [ ] Refactor (no intended behavior change)
- [ ] Dependency or tooling

## Testing

- [x] `UV_CACHE_DIR=/private/tmp/rooted-uv-cache uv run pytest`
- [x] `UV_CACHE_DIR=/private/tmp/rooted-uv-cache uv run ruff check ...`
- [x] `UV_CACHE_DIR=/private/tmp/rooted-uv-cache uv run ruff format --check ...`

## Checklist

- [x] PR targets `main`
- [ ] CI green before merge

Closes #73
